### PR TITLE
詳細なデプロイガイドとクイックスタートドキュメントの追加

### DIFF
--- a/docs/deployment/render-free.md
+++ b/docs/deployment/render-free.md
@@ -1,0 +1,84 @@
+# Renderでの無料デプロイガイド
+
+このガイドでは、ShardXをRenderの無料プランを使用してデプロイする方法を説明します。
+
+## 前提条件
+
+- GitHubアカウント
+- Renderアカウント（無料）
+
+## 手順
+
+### 1. Renderアカウントの作成
+
+1. [Render](https://render.com/)にアクセスし、「Sign Up」をクリックします
+2. GitHubアカウントでサインアップすることをお勧めします（連携が簡単になります）
+
+### 2. ワンクリックデプロイ
+
+最も簡単な方法は、以下のボタンをクリックすることです：
+
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/enablerdao/ShardX)
+
+### 3. 手動デプロイ（ワンクリックデプロイがうまくいかない場合）
+
+1. Renderダッシュボードで「New +」→「Web Service」をクリックします
+2. GitHubリポジトリを連携し、「enablerdao/ShardX」を選択します
+3. 以下の設定を入力します：
+   - **Name**: shardx-node
+   - **Environment**: Docker
+   - **Branch**: main
+   - **Plan**: Free
+
+4. 「Create Web Service」をクリックします
+
+5. 次に、「New +」→「Web Service」をクリックして、ウェブインターフェースをデプロイします
+6. 同じリポジトリを選択し、以下の設定を入力します：
+   - **Name**: shardx-web
+   - **Environment**: Node
+   - **Branch**: main
+   - **Build Command**: `cd web && npm install && npm run build`
+   - **Start Command**: `cd web && npm start`
+   - **Plan**: Free
+   - **Advanced** → **Environment Variables**:
+     - `PORT`: 52153
+     - `API_URL`: https://shardx-node.onrender.com
+
+7. 「Create Web Service」をクリックします
+
+### 4. デプロイの確認
+
+1. デプロイが完了するまで数分待ちます（Renderダッシュボードで進行状況を確認できます）
+2. デプロイが完了したら、以下のURLにアクセスできます：
+   - ウェブインターフェース: https://shardx-web.onrender.com
+   - API: https://shardx-node.onrender.com/api/v1/info
+
+## 無料プランの制限事項
+
+Renderの無料プランには以下の制限があります：
+
+- 毎月750時間の実行時間（1つのサービスを常時実行可能）
+- 512MB RAM
+- 共有CPU
+- 15分間のアイドル後にスリープ状態になる（次のリクエストで自動的に起動）
+
+これらの制限は開発やテスト目的には十分ですが、本番環境では有料プランへのアップグレードを検討してください。
+
+## トラブルシューティング
+
+### デプロイに失敗する場合
+
+1. Renderダッシュボードでログを確認します
+2. 一般的な問題：
+   - メモリ不足: 無料プランでは512MBのRAMしか使用できません。設定で`INITIAL_SHARDS`を減らしてみてください。
+   - ビルドタイムアウト: 無料プランではビルド時間が制限されています。Dockerfileを最適化してみてください。
+
+### サービスがスリープから復帰しない場合
+
+1. Renderダッシュボードでサービスを手動で再起動します
+2. 無料プランでは15分間のアイドル後にスリープ状態になります。定期的なpingを設定して、サービスをアクティブに保つことができます。
+
+## 次のステップ
+
+- [API リファレンス](../api/README.md)を参照して、ShardX APIの使用方法を学びます
+- [開発者ガイド](../developers/README.md)を参照して、ShardXの開発方法を学びます

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,105 @@
+# ShardX クイックスタートガイド
+
+このガイドでは、ShardXを5分以内に起動する方法を説明します。
+
+## 1. 最速の方法（Docker）
+
+Dockerがインストールされている場合、以下のコマンドを実行するだけでShardXを起動できます：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/enablerdao/ShardX/main/install.sh | bash
+```
+
+または、手動でDockerコマンドを実行することもできます：
+
+```bash
+docker run -d -p 54867:54867 -p 54868:54868 --name shardx enablerdao/shardx:latest
+```
+
+## 2. OS別インストール方法
+
+### Linux (Ubuntu/Debian)
+
+```bash
+# 依存関係をインストール
+sudo apt update && sudo apt install -y git curl build-essential libssl-dev pkg-config
+
+# ShardXをクローンして起動
+git clone https://github.com/enablerdao/ShardX.git
+cd ShardX
+./scripts/linux_install.sh
+./scripts/run.sh
+```
+
+### macOS
+
+```bash
+# Homebrewがない場合はインストール
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+# 依存関係をインストール
+brew install git curl rust
+
+# ShardXをクローンして起動
+git clone https://github.com/enablerdao/ShardX.git
+cd ShardX
+./scripts/mac_install.sh
+./scripts/run.sh
+```
+
+### Windows
+
+PowerShellを管理者権限で実行し、以下のコマンドを実行します：
+
+```powershell
+# Rustをインストール
+Invoke-WebRequest -Uri https://win.rustup.rs/x86_64 -OutFile rustup-init.exe
+.\rustup-init.exe -y
+
+# ShardXをクローンして起動
+git clone https://github.com/enablerdao/ShardX.git
+cd ShardX
+.\scripts\windows_install.ps1
+.\scripts\run.ps1
+```
+
+## 3. クラウドにデプロイ
+
+以下のボタンをクリックするだけで、ShardXをクラウドにデプロイできます：
+
+- [Renderにデプロイ](https://render.com/deploy?repo=https://github.com/enablerdao/ShardX)
+- [Railwayにデプロイ](https://railway.app/template/ShardX)
+- [Vercelにデプロイ](https://vercel.com/new/clone?repository-url=https://github.com/enablerdao/ShardX)
+
+詳細な手順は[Renderデプロイガイド](deployment/render-free.md)を参照してください。
+
+## 4. 動作確認
+
+ShardXが起動したら、以下のURLにアクセスできます：
+
+- ウェブインターフェース: http://localhost:54867
+- API: http://localhost:54868/api/v1/info
+
+APIを使用して基本的な操作を行うことができます：
+
+```bash
+# システム情報を取得
+curl http://localhost:54868/api/v1/info
+
+# トランザクションを作成
+curl -X POST http://localhost:54868/api/v1/transactions \
+  -H "Content-Type: application/json" \
+  -d '{"sender":"test1","receiver":"test2","amount":100}'
+
+# トランザクション一覧を取得
+curl http://localhost:54868/api/v1/transactions
+
+# シャード情報を取得
+curl http://localhost:54868/api/v1/shards
+```
+
+## 5. 次のステップ
+
+- [API リファレンス](api/README.md)を参照して、ShardX APIの使用方法を学びます
+- [開発者ガイド](developers/README.md)を参照して、ShardXの開発方法を学びます
+- [デプロイガイド](deployment/README.md)を参照して、ShardXの本番環境へのデプロイ方法を学びます


### PR DESCRIPTION
このPRでは、以下のドキュメントを追加しています：

- **Renderでの無料デプロイガイド**: Renderの無料プランを使用してShardXをデプロイする詳細な手順
- **クイックスタートガイド**: 5分以内にShardXを起動するための簡単な手順（OS別の手順を含む）

これらのドキュメントにより、ユーザーはより簡単にShardXを試すことができるようになります。「まず動かす、検証する、改善する」の精神に基づいて、実際の使用例と具体的なコマンドを提供しています。