### PR TITLE
Add multi-platform deployment support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,16 @@
 version = 4
 
 [[package]]
+name = "Inflector"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
+dependencies = [
+ "lazy_static",
+ "regex",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16,6 +26,28 @@ name = "adler2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.15",
+ "once_cell",
+ "version_check",
+]
 
 [[package]]
 name = "ahash"
@@ -60,6 +92,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "anyhow"
+version = "1.0.97"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
+
+[[package]]
+name = "anymap2"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
+
+[[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "ascii-canvas"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
+dependencies = [
+ "term",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -67,7 +166,29 @@ checksum = "d556ec1359574147ec0c4fc5eb525f3f23263a592b1a9c07e0a75b427de55c97"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "async_io_stream"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d7b9decdf35d8908a7e3ef02f64c5e9b1695e230154c0e8de3969142d9b94c"
+dependencies = [
+ "futures",
+ "pharos",
+ "rustc_version",
+]
+
+[[package]]
+name = "auto_impl"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e12882f59de5360c748c4cbf569a042d5fb0eb515f7bea9c1f470b47f6ffbd73"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -75,6 +196,55 @@ name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
+name = "axum"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bitflags 1.3.2",
+ "bytes",
+ "futures-util",
+ "http 0.2.12",
+ "http-body",
+ "hyper",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 0.2.12",
+ "http-body",
+ "mime",
+ "rustversion",
+ "tower-layer",
+ "tower-service",
+]
 
 [[package]]
 name = "backtrace"
@@ -88,8 +258,14 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
@@ -104,10 +280,107 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64ct"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
+
+[[package]]
+name = "bech32"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.65.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfdf7b466f9a4903edc73f95d6d2bcd5baf8ae620638762244d3f60143643cc5"
+dependencies = [
+ "bitflags 1.3.2",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "peeking_take_while",
+ "prettyplease 0.2.31",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
 name = "bitflags"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+
+[[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
+name = "blake3"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "675f87afced0413c9bb02843499dbbd3882a237645883f71a2b59644a6d2f753"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq 0.3.1",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "block-buffer"
@@ -119,10 +392,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "sha2",
+ "tinyvec",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+
+[[package]]
+name = "byte-slice-cast"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
 name = "byteorder"
@@ -135,6 +424,67 @@ name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bzip2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
+name = "camino"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
@@ -142,7 +492,18 @@ version = "1.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
 dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -167,6 +528,198 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6088f3ae8c3608d19260cd7445411865a485688711b78b5be70d78cd96136f83"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22a7ef7f676155edfb82daa97f99441f3ebf4a58d5e32f295a56259f1b6facc8"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+
+[[package]]
+name = "coins-bip32"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b6be4a5df2098cd811f3194f64ddb96c267606bffd9689ac7b0160097b01ad3"
+dependencies = [
+ "bs58",
+ "coins-core",
+ "digest 0.10.7",
+ "hmac",
+ "k256",
+ "serde",
+ "sha2",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "coins-bip39"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db8fba409ce3dc04f7d804074039eb68b960b0829161f8e06c95fea3f122528"
+dependencies = [
+ "bitvec",
+ "coins-bip32",
+ "hmac",
+ "once_cell",
+ "pbkdf2 0.12.2",
+ "rand",
+ "sha2",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "coins-core"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5286a0843c21f8367f7be734f89df9b822e0321d8bcce8d6e735aadff7d74979"
+dependencies = [
+ "base64 0.21.7",
+ "bech32",
+ "bs58",
+ "digest 0.10.7",
+ "generic-array",
+ "hex",
+ "ripemd",
+ "serde",
+ "serde_derive",
+ "sha2",
+ "sha3",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "const-hex"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b0485bab839b018a8f1723fc5391819fea5f8f0f32288ef8a735fd096b6160c"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "hex",
+ "proptest",
+ "serde",
+]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const_format"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126f97965c8ad46d6d9163268ff28432e8f6a1196a55578867832e3049df63dd"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -182,6 +735,94 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
+
+[[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -192,13 +833,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest 0.10.7",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "dashmap"
 version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
  "cfg-if",
- "hashbrown",
+ "hashbrown 0.14.3",
  "lock_api",
  "once_cell",
  "parking_lot_core",
@@ -211,13 +888,135 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "575f75dfd25738df5b91b8e43e14d44bda14637a58fae779fd2b064f8bf3e010"
 
 [[package]]
+name = "der"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
+
+[[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
+name = "derive-new"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3418329ca0ad70234b9735dc4ceed10af4df60eff9c8e7b06cb5e520d92c3535"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_more"
+version = "0.99.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3da29a38df43d6f156149c9b43ded5e018ddff2a855cf2cfd62e8cd7d079c69f"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "derive_more"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.4",
+ "const-oid",
  "crypto-common",
+ "subtle",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
@@ -228,7 +1027,103 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest 0.10.7",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest 0.10.7",
+ "ff",
+ "generic-array",
+ "group",
+ "pkcs8",
+ "rand_core",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "ena"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d248bdd43ce613d87415282f69b9bb99d947d290b10962dd6c56233312c2ad5"
+dependencies = [
+ "log",
 ]
 
 [[package]]
@@ -238,6 +1133,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "enr"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a3d8dc56e02f954cac8eb489772c552c473346fc34f67412bb6244fd647f7e4"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "hex",
+ "k256",
+ "log",
+ "rand",
+ "rlp",
+ "serde",
+ "sha3",
+ "zeroize",
 ]
 
 [[package]]
@@ -260,10 +1173,434 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "eth-keystore"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fda3bf123be441da5260717e0661c25a2fd9cb2b2c1d20bf2e05580047158ab"
+dependencies = [
+ "aes",
+ "ctr",
+ "digest 0.10.7",
+ "hex",
+ "hmac",
+ "pbkdf2 0.11.0",
+ "rand",
+ "scrypt",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sha3",
+ "thiserror 1.0.69",
+ "uuid 0.8.2",
+]
+
+[[package]]
+name = "ethabi"
+version = "18.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7413c5f74cc903ea37386a8965a936cbeb334bd270862fdece542c1b2dcbc898"
+dependencies = [
+ "ethereum-types",
+ "hex",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "sha3",
+ "thiserror 1.0.69",
+ "uint",
+]
+
+[[package]]
+name = "ethbloom"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c22d4b5885b6aa2fe5e8b9329fb8d232bf739e434e6b87347c63bdd00c120f60"
+dependencies = [
+ "crunchy",
+ "fixed-hash",
+ "impl-codec",
+ "impl-rlp",
+ "impl-serde",
+ "scale-info",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "ethereum-types"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d215cbf040552efcbe99a38372fe80ab9d00268e20012b79fcd0f073edd8ee"
+dependencies = [
+ "ethbloom",
+ "fixed-hash",
+ "impl-codec",
+ "impl-rlp",
+ "impl-serde",
+ "primitive-types",
+ "scale-info",
+ "uint",
+]
+
+[[package]]
+name = "ethers"
+version = "2.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "816841ea989f0c69e459af1cf23a6b0033b19a55424a1ea3a30099becdb8dec0"
+dependencies = [
+ "ethers-addressbook",
+ "ethers-contract",
+ "ethers-core",
+ "ethers-etherscan",
+ "ethers-middleware",
+ "ethers-providers",
+ "ethers-signers",
+ "ethers-solc",
+]
+
+[[package]]
+name = "ethers-addressbook"
+version = "2.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5495afd16b4faa556c3bba1f21b98b4983e53c1755022377051a975c3b021759"
+dependencies = [
+ "ethers-core",
+ "once_cell",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "ethers-contract"
+version = "2.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fceafa3578c836eeb874af87abacfb041f92b4da0a78a5edd042564b8ecdaaa"
+dependencies = [
+ "const-hex",
+ "ethers-contract-abigen",
+ "ethers-contract-derive",
+ "ethers-core",
+ "ethers-providers",
+ "futures-util",
+ "once_cell",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "ethers-contract-abigen"
+version = "2.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04ba01fbc2331a38c429eb95d4a570166781f14290ef9fdb144278a90b5a739b"
+dependencies = [
+ "Inflector",
+ "const-hex",
+ "dunce",
+ "ethers-core",
+ "ethers-etherscan",
+ "eyre",
+ "prettyplease 0.2.31",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "syn 2.0.100",
+ "toml",
+ "walkdir",
+]
+
+[[package]]
+name = "ethers-contract-derive"
+version = "2.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87689dcabc0051cde10caaade298f9e9093d65f6125c14575db3fd8c669a168f"
+dependencies = [
+ "Inflector",
+ "const-hex",
+ "ethers-contract-abigen",
+ "ethers-core",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "ethers-core"
+version = "2.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82d80cc6ad30b14a48ab786523af33b37f28a8623fc06afd55324816ef18fb1f"
+dependencies = [
+ "arrayvec",
+ "bytes",
+ "cargo_metadata",
+ "chrono",
+ "const-hex",
+ "elliptic-curve",
+ "ethabi",
+ "generic-array",
+ "k256",
+ "num_enum",
+ "once_cell",
+ "open-fastrlp",
+ "rand",
+ "rlp",
+ "serde",
+ "serde_json",
+ "strum",
+ "syn 2.0.100",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tiny-keccak",
+ "unicode-xid",
+]
+
+[[package]]
+name = "ethers-etherscan"
+version = "2.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79e5973c26d4baf0ce55520bd732314328cabe53193286671b47144145b9649"
+dependencies = [
+ "chrono",
+ "ethers-core",
+ "reqwest",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
+name = "ethers-middleware"
+version = "2.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48f9fdf09aec667c099909d91908d5eaf9be1bd0e2500ba4172c1d28bfaa43de"
+dependencies = [
+ "async-trait",
+ "auto_impl",
+ "ethers-contract",
+ "ethers-core",
+ "ethers-etherscan",
+ "ethers-providers",
+ "ethers-signers",
+ "futures-channel",
+ "futures-locks",
+ "futures-util",
+ "instant",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "tracing-futures",
+ "url",
+]
+
+[[package]]
+name = "ethers-providers"
+version = "2.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6434c9a33891f1effc9c75472e12666db2fa5a0fec4b29af6221680a6fe83ab2"
+dependencies = [
+ "async-trait",
+ "auto_impl",
+ "base64 0.21.7",
+ "bytes",
+ "const-hex",
+ "enr",
+ "ethers-core",
+ "futures-core",
+ "futures-timer",
+ "futures-util",
+ "hashers",
+ "http 0.2.12",
+ "instant",
+ "jsonwebtoken",
+ "once_cell",
+ "pin-project",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-tungstenite 0.20.1",
+ "tracing",
+ "tracing-futures",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "ws_stream_wasm",
+]
+
+[[package]]
+name = "ethers-signers"
+version = "2.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "228875491c782ad851773b652dd8ecac62cda8571d3bc32a5853644dd26766c2"
+dependencies = [
+ "async-trait",
+ "coins-bip32",
+ "coins-bip39",
+ "const-hex",
+ "elliptic-curve",
+ "eth-keystore",
+ "ethers-core",
+ "rand",
+ "sha2",
+ "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
+name = "ethers-solc"
+version = "2.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66244a771d9163282646dbeffe0e6eca4dda4146b6498644e678ac6089b11edd"
+dependencies = [
+ "cfg-if",
+ "const-hex",
+ "dirs",
+ "dunce",
+ "ethers-core",
+ "glob",
+ "home",
+ "md-5",
+ "num_cpus",
+ "once_cell",
+ "path-slash",
+ "rayon",
+ "regex",
+ "semver",
+ "serde",
+ "serde_json",
+ "solang-parser",
+ "svm-rs",
+ "thiserror 1.0.69",
+ "tiny-keccak",
+ "tokio",
+ "tracing",
+ "walkdir",
+ "yansi",
+]
+
+[[package]]
+name = "eyre"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
+dependencies = [
+ "indenter",
+ "once_cell",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "filetime"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "fixed-hash"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
+dependencies = [
+ "byteorder",
+ "rand",
+ "rustc-hex",
+ "static_assertions",
+]
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "flate2"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -273,6 +1610,28 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fragile"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -323,6 +1682,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
+name = "futures-locks"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45ec6fe3675af967e67c5536c0b9d44e34e6c52f86bedc4ea49c5317b8e94d06"
+dependencies = [
+ "futures-channel",
+ "futures-task",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -330,7 +1699,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -344,6 +1713,16 @@ name = "futures-task"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+dependencies = [
+ "gloo-timers",
+ "send_wrapper 0.4.0",
+]
 
 [[package]]
 name = "futures-util"
@@ -364,6 +1743,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -371,6 +1759,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -393,7 +1782,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi 0.13.3+wasi-0.2.2",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -401,6 +1790,35 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "glob"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+
+[[package]]
+name = "gloo-timers"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core",
+ "subtle",
+]
 
 [[package]]
 name = "h2"
@@ -422,13 +1840,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7db2ff139bba50379da6aa0766b52fdcb62cb5b263009b09ed58ba604e14bbd1"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "num-traits",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+dependencies = [
+ "ahash 0.7.8",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
- "ahash",
+ "ahash 0.8.11",
  "allocator-api2",
+]
+
+[[package]]
+name = "hashers"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2bca93b15ea5a746f220e56587f71e73c6165eab783df9e26590069953e3c30"
+dependencies = [
+ "fxhash",
 ]
 
 [[package]]
@@ -456,6 +1903,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
 name = "hermit-abi"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -466,6 +1931,24 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "home"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "http"
@@ -499,6 +1982,12 @@ dependencies = [
  "http 0.2.12",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "http-range-header"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "add0ab9360ddbd88cfeb3bd9574a1d85cfdfa14db10b3e21d3700dbc4328758f"
 
 [[package]]
 name = "httparse"
@@ -540,6 +2029,33 @@ dependencies = [
  "tower-service",
  "tracing",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -680,7 +2196,17 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "idna"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -705,14 +2231,82 @@ dependencies = [
 ]
 
 [[package]]
+name = "impl-codec"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
+dependencies = [
+ "parity-scale-codec",
+]
+
+[[package]]
+name = "impl-rlp"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
+dependencies = [
+ "rlp",
+]
+
+[[package]]
+name = "impl-serde"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc88fc67028ae3db0c853baa36269d398d5f45b6982f95549ff5def78c935cd"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "impl-trait-for-tuples"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
+
+[[package]]
 name = "indexmap"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.14.3",
 ]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "is-terminal"
@@ -720,9 +2314,36 @@ version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.5.0",
  "libc",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -730,6 +2351,15 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jobserver"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -742,10 +2372,234 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonrpc-core"
+version = "18.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14f7f76aef2d054868398427f6c54943cf3d1caa9a7ec7d0c38d69df97a965eb"
+dependencies = [
+ "futures",
+ "futures-executor",
+ "futures-util",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "8.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6971da4d9c3aa03c3d8f3ff0f4155b534aad021292003895a469716b2a230378"
+dependencies = [
+ "base64 0.21.7",
+ "pem",
+ "ring 0.16.20",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
+name = "k256"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
+dependencies = [
+ "cfg-if",
+ "ecdsa",
+ "elliptic-curve",
+ "once_cell",
+ "sha2",
+ "signature",
+]
+
+[[package]]
+name = "keccak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+dependencies = [
+ "cpufeatures",
+]
+
+[[package]]
+name = "kstring"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "558bf9508a558512042d3095138b1f7b8fe90c5467d94f9f1da28b3731c5dbd1"
+dependencies = [
+ "serde",
+ "static_assertions",
+]
+
+[[package]]
+name = "lalrpop"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cb077ad656299f160924eb2912aa147d7339ea7d69e1b5517326fdcec3c1ca"
+dependencies = [
+ "ascii-canvas",
+ "bit-set",
+ "ena",
+ "itertools 0.11.0",
+ "lalrpop-util",
+ "petgraph",
+ "regex",
+ "regex-syntax",
+ "string_cache",
+ "term",
+ "tiny-keccak",
+ "unicode-xid",
+ "walkdir",
+]
+
+[[package]]
+name = "lalrpop-util"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+
+[[package]]
+name = "libloading"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
+dependencies = [
+ "cfg-if",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "libm"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
+
+[[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags 2.9.0",
+ "libc",
+ "redox_syscall",
+]
+
+[[package]]
+name = "librocksdb-sys"
+version = "0.11.0+8.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3386f101bcb4bd252d8e9d2fb41ec3b0862a15a62b478c355b2982efa469e3e"
+dependencies = [
+ "bindgen",
+ "bzip2-sys",
+ "cc",
+ "glob",
+ "libc",
+ "libz-sys",
+ "lz4-sys",
+ "zstd-sys",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b70e7a7df205e92a1a4cd9aaae7898dac0aa555503cc0a649494d0d60e7651d"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
+
+[[package]]
+name = "liquid"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a494c3f9dad3cb7ed16f1c51812cbe4b29493d6c2e5cd1e2b87477263d9534d"
+dependencies = [
+ "liquid-core",
+ "liquid-derive",
+ "liquid-lib",
+ "serde",
+]
+
+[[package]]
+name = "liquid-core"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc623edee8a618b4543e8e8505584f4847a4e51b805db1af6d9af0a3395d0d57"
+dependencies = [
+ "anymap2",
+ "itertools 0.14.0",
+ "kstring",
+ "liquid-derive",
+ "pest",
+ "pest_derive",
+ "regex",
+ "serde",
+ "time",
+]
+
+[[package]]
+name = "liquid-derive"
+version = "0.26.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de66c928222984aea59fcaed8ba627f388aaac3c1f57dcb05cc25495ef8faefe"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "liquid-lib"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9befeedd61f5995bc128c571db65300aeb50d62e4f0542c88282dbcb5f72372a"
+dependencies = [
+ "itertools 0.14.0",
+ "liquid-core",
+ "percent-encoding",
+ "regex",
+ "time",
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "litemap"
@@ -770,10 +2624,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
 
 [[package]]
+name = "lru"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a83fb7698b3643a0e34f9ae6f2e8f0178c0fd42f8b59d493aa271ff3a5bf21"
+dependencies = [
+ "hashbrown 0.14.3",
+]
+
+[[package]]
+name = "lz4-sys"
+version = "1.11.1+lz4-1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "matrixmultiply"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9380b911e3e96d10c1f415da0876389aaf1b56759054eeb0de7df940c456ba1a"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "memmap2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "mime"
@@ -790,6 +2704,12 @@ dependencies = [
  "mime",
  "unicase",
 ]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -812,6 +2732,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockall"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c84490118f2ee2d74570d114f3d0493cbf02790df303d2707606c3e14e07c96"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "lazy_static",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22ce75669015c4f47b289fd4d4f56e894e4c96003ffdf3ac51313126f94c6cbb"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "multer"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -825,8 +2772,100 @@ dependencies = [
  "log",
  "memchr",
  "mime",
- "spin",
+ "spin 0.9.8",
  "version_check",
+]
+
+[[package]]
+name = "multimap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
+name = "native-tls"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
+name = "ndarray"
+version = "0.15.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb12d4e967ec485a5f71c6311fe28158e9d6f4bc4a447b474184d0f91a8fa32"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "rawpointer",
+]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -836,6 +2875,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi 0.3.9",
+ "libc",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
+dependencies = [
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -852,6 +2923,121 @@ name = "once_cell"
 version = "1.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "open-fastrlp"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "786393f80485445794f6043fd3138854dd109cc6c4bd1a6383db304c9ce9b9ce"
+dependencies = [
+ "arrayvec",
+ "auto_impl",
+ "bytes",
+ "ethereum-types",
+ "open-fastrlp-derive",
+]
+
+[[package]]
+name = "open-fastrlp-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "003b2be5c6c53c1cfeb0a238b8a1c3915cd410feb684457a36c10038f764bb1c"
+dependencies = [
+ "bytes",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "openssl"
+version = "0.10.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e14130c6a98cd258fdcb0fb6d744152343ff729cbfcb28c656a9d12b999fbcd"
+dependencies = [
+ "bitflags 2.9.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bb61ea9811cc39e3c2069f40b8b8e2e70d8569b361f879786cc7ed48b777cdd"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "parity-scale-codec"
+version = "3.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9fde3d0718baf5bc92f577d652001da0f8d54cd03a7974e118d04fc888dc23d"
+dependencies = [
+ "arrayvec",
+ "bitvec",
+ "byte-slice-cast",
+ "const_format",
+ "impl-trait-for-tuples",
+ "parity-scale-codec-derive",
+ "rustversion",
+ "serde",
+]
+
+[[package]]
+name = "parity-scale-codec-derive"
+version = "3.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581c837bb6b9541ce7faa9377c20616e4fb7650f6b0f68bc93c827ee504fb7b3"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
 
 [[package]]
 name = "parking_lot"
@@ -873,7 +3059,67 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "password-hash"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
+dependencies = [
+ "base64ct",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "path-slash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
+
+[[package]]
+name = "pbkdf2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
+dependencies = [
+ "digest 0.10.7",
+ "hmac",
+ "password-hash",
+ "sha2",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest 0.10.7",
+ "hmac",
+]
+
+[[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
+name = "pem"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
+dependencies = [
+ "base64 0.13.1",
 ]
 
 [[package]]
@@ -881,6 +3127,113 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "pest"
+version = "2.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b7cafe60d6cf8e62e1b9b2ea516a089c008945bb5a275416789e7db0bc199dc"
+dependencies = [
+ "memchr",
+ "thiserror 2.0.12",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "816518421cfc6887a0d62bf441b6ffb4536fcc926395a69e1a85852d4363f57e"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d1396fd3a870fc7838768d171b4616d5c91f6cc25e377b673d714567d99377b"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e58089ea25d717bfd31fb534e4f3afcc2cc569c70de3e239778991ea3b7dea"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
+name = "pharos"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9567389417feee6ce15dd6527a8a1ecac205ef62c2932bcf3d9f6fc5b78b414"
+dependencies = [
+ "futures",
+ "rustc_version",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project"
@@ -899,7 +3252,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -915,12 +3268,150 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy 0.8.23",
+]
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "predicates"
+version = "2.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59230a63c37f3e18569bdb90e4a89cbf5bf8b06fea0b84e65ea10cc4df47addd"
+dependencies = [
+ "difflib",
+ "float-cmp",
+ "itertools 0.10.5",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
+dependencies = [
+ "proc-macro2",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5316f57387668042f561aae71480de936257848f9c43ce528e311d89a07cadeb"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "primal-check"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0d895b311e3af9902528fbb8f928688abbd95872819320517cc24ca6b2bd08"
+dependencies = [
+ "num-integer",
+]
+
+[[package]]
+name = "primitive-types"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
+dependencies = [
+ "fixed-hash",
+ "impl-codec",
+ "impl-rlp",
+ "impl-serde",
+ "scale-info",
+ "uint",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -933,6 +3424,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
+dependencies = [
+ "bitflags 2.9.0",
+ "lazy_static",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "unarray",
+]
+
+[[package]]
+name = "prost"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
+dependencies = [
+ "bytes",
+ "heck 0.4.1",
+ "itertools 0.10.5",
+ "lazy_static",
+ "log",
+ "multimap",
+ "petgraph",
+ "prettyplease 0.1.25",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn 1.0.109",
+ "tempfile",
+ "which",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
+dependencies = [
+ "anyhow",
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
+dependencies = [
+ "prost",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -940,6 +3501,12 @@ checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -972,12 +3539,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_distr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [
+ "num-traits",
+ "rand",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.15",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1010,10 +3633,227 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "reqwest"
+version = "0.11.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http 0.2.12",
+ "http-body",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "system-configuration",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-rustls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+ "winreg",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin 0.5.2",
+ "untrusted 0.7.1",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.15",
+ "libc",
+ "untrusted 0.9.0",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "ripemd"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "rlp"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
+dependencies = [
+ "bytes",
+ "rlp-derive",
+ "rustc-hex",
+]
+
+[[package]]
+name = "rlp-derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e33d7b2abe0c340d8797fe2907d3f20d3b5ea5908683618bfe80df7f621f672a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "rocksdb"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb6f170a4041d50a0ce04b0d2e14916d6ca863ea2e422689a5b694395d299ffe"
+dependencies = [
+ "libc",
+ "librocksdb-sys",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hex"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustfft"
+version = "6.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43806561bc506d0c5d160643ad742e3161049ac01027b5e6d7524091fd401d86"
+dependencies = [
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "primal-check",
+ "strength_reduce",
+ "transpose",
+ "version_check",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.9.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7178faa4b75a30e269c71e61c353ce2748cf3d76f0c44c393f4e60abf49b825"
+dependencies = [
+ "bitflags 2.9.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.3",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring 0.17.14",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.7",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring 0.17.14",
+ "untrusted 0.9.0",
+]
 
 [[package]]
 name = "rustversion"
@@ -1028,6 +3868,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "scale-info"
+version = "2.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346a3b32eba2640d17a9cb5927056b08f3de90f65b72fe09402c2ad07d684d0b"
+dependencies = [
+ "cfg-if",
+ "derive_more 1.0.0",
+ "parity-scale-codec",
+ "scale-info-derive",
+]
+
+[[package]]
+name = "scale-info-derive"
+version = "2.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6630024bf739e2179b91fb424b28898baf819414262c5d376677dbff1fe7ebf"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "scan_fmt"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b53b0a5db882a8e2fdaae0a43f7b39e7e9082389e978398bdf223a55b581248"
+dependencies = [
+ "regex",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1038,6 +3938,104 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "scrypt"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f9e24d2b632954ded8ab2ef9fea0a0c769ea56ea98bddbafbad22caeeadf45d"
+dependencies = [
+ "hmac",
+ "pbkdf2 0.11.0",
+ "salsa20",
+ "sha2",
+]
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring 0.17.14",
+ "untrusted 0.9.0",
+]
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
+dependencies = [
+ "secp256k1-sys",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70a129b9e9efbfb223753b9163c4ab3b13cff7fd9c7f010fbac25ab4099fa07e"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.9.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "send_wrapper"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
+
+[[package]]
+name = "send_wrapper"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
@@ -1056,7 +4054,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1068,6 +4066,25 @@ dependencies = [
  "itoa",
  "memchr",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
+dependencies = [
+ "itoa",
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+dependencies = [
  "serde",
 ]
 
@@ -1084,6 +4101,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha-1"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1091,7 +4121,7 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1102,32 +4132,69 @@ checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+dependencies = [
+ "digest 0.10.7",
+ "keccak",
 ]
 
 [[package]]
 name = "shardx"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
+ "anyhow",
  "async-trait",
+ "axum",
  "base64 0.13.1",
+ "bincode",
+ "blake3",
  "chrono",
+ "criterion",
  "dashmap",
+ "ed25519-dalek",
  "env_logger",
+ "ethers",
  "futures",
- "hashbrown",
+ "futures-util",
+ "hashbrown 0.14.3",
  "hex",
  "indexmap",
  "litemap",
  "log",
+ "lru",
+ "mockall",
+ "ndarray",
+ "num_cpus",
+ "prost",
+ "prost-build",
+ "prost-types",
  "rand",
+ "rayon",
+ "reqwest",
+ "rocksdb",
  "serde",
  "serde_json",
  "sha2",
- "thiserror",
+ "tempfile",
+ "thiserror 1.0.69",
+ "threadpool",
  "tokio",
- "uuid",
+ "tokio-test",
+ "tokio-tungstenite 0.20.1",
+ "tower",
+ "tower-http",
+ "tract-onnx",
+ "tungstenite 0.20.1",
+ "uuid 1.16.0",
  "warp",
+ "web3",
 ]
 
 [[package]]
@@ -1144,6 +4211,34 @@ checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest 0.10.7",
+ "rand_core",
+]
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.12",
+ "time",
+]
+
+[[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"
@@ -1171,16 +4266,155 @@ dependencies = [
 ]
 
 [[package]]
+name = "soketto"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d1c5305e39e09653383c2c7244f2f78b3bcae37cf50c64cb4789c9f5096ec2"
+dependencies = [
+ "base64 0.13.1",
+ "bytes",
+ "futures",
+ "httparse",
+ "log",
+ "rand",
+ "sha-1",
+]
+
+[[package]]
+name = "solang-parser"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c425ce1c59f4b154717592f0bdf4715c3a1d55058883622d3157e1f0908a5b26"
+dependencies = [
+ "itertools 0.11.0",
+ "lalrpop",
+ "lalrpop-util",
+ "phf",
+ "thiserror 1.0.69",
+ "unicode-xid",
+]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strength_reduce"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
+
+[[package]]
+name = "string-interner"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e2531d8525b29b514d25e275a43581320d587b86db302b9a7e464bac579648"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.11.2",
+ "serde",
+]
+
+[[package]]
+name = "string_cache"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "938d512196766101d333398efde81bc1f37b00cb42c2f8350e5df639f040bbbe"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared",
+ "precomputed-hash",
+]
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "svm-rs"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11297baafe5fa0c99d5722458eac6a5e25c01eb1b8e5cd137f54079093daa7a4"
+dependencies = [
+ "dirs",
+ "fs2",
+ "hex",
+ "once_cell",
+ "reqwest",
+ "semver",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror 1.0.69",
+ "url",
+ "zip",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -1194,6 +4428,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
 name = "synstructure"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1201,7 +4441,69 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "tar"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488960f40a3fd53d72c2a29a58722561dee8afdd175bd88e3db4677d7b2ba600"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.1",
+ "once_cell",
+ "rustix 1.0.2",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
+ "winapi",
 ]
 
 [[package]]
@@ -1214,12 +4516,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -1230,7 +4547,67 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
+]
+
+[[package]]
+name = "time"
+version = "0.3.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dad298b01a40a23aac4580b67e3dbedb7cc8402f3592d7f49469de2ea4aecdd8"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "765c97a5b985b7c11d7bc27fa927dc4fe6af3a6dfb021d28deb60d3bf51e76ef"
+
+[[package]]
+name = "time-macros"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8093bc3e81c3bc5f7879de09619d06c9a5a5e45ca44dfeeb7225bae38005c5c"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -1242,6 +4619,31 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -1269,7 +4671,66 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-test"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2468baabc3311435b55dd935f702f42cd1b8abb7e754fb7dfb16bd36aa88f9f7"
+dependencies = [
+ "async-stream",
+ "bytes",
+ "futures-core",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tungstenite 0.20.1",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1281,7 +4742,7 @@ dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite",
+ "tungstenite 0.21.0",
 ]
 
 [[package]]
@@ -1292,10 +4753,86 @@ checksum = "6b9590b93e6fcc1739458317cccd391ad3955e2bde8913edf6f95f9e65a8f034"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
+dependencies = [
+ "bitflags 2.9.0",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http 0.2.12",
+ "http-body",
+ "http-range-header",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"
@@ -1311,7 +4848,19 @@ checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1324,10 +4873,176 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "pin-project",
+ "tracing",
+]
+
+[[package]]
+name = "tract-core"
+version = "0.20.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1518c2b81258326ade7659d9c71d3747fee884cb792afdd09977fd4693cf1d"
+dependencies = [
+ "anyhow",
+ "bit-set",
+ "derive-new",
+ "downcast-rs",
+ "dyn-clone",
+ "lazy_static",
+ "log",
+ "maplit",
+ "ndarray",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "rustfft",
+ "smallvec",
+ "tract-data",
+ "tract-linalg",
+]
+
+[[package]]
+name = "tract-data"
+version = "0.20.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68315af15998e0cf06c29f017905c083d4f964b3114d8436ef6887b11fa39f56"
+dependencies = [
+ "anyhow",
+ "half",
+ "itertools 0.10.5",
+ "lazy_static",
+ "maplit",
+ "ndarray",
+ "nom",
+ "num-integer",
+ "num-traits",
+ "scan_fmt",
+ "smallvec",
+ "string-interner",
+]
+
+[[package]]
+name = "tract-hir"
+version = "0.20.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be070982d0310dc8f9164251cef6e67514bd64c844066d853adfe45d65f2622a"
+dependencies = [
+ "derive-new",
+ "log",
+ "tract-core",
+]
+
+[[package]]
+name = "tract-linalg"
+version = "0.20.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4332a4be4cb2c12c317d0e092dcf5b09479314be18b906333113429ec258d36"
+dependencies = [
+ "cc",
+ "derive-new",
+ "downcast-rs",
+ "dyn-clone",
+ "half",
+ "lazy_static",
+ "liquid",
+ "liquid-core",
+ "log",
+ "num-traits",
+ "paste",
+ "scan_fmt",
+ "smallvec",
+ "tract-data",
+ "unicode-normalization",
+ "walkdir",
+]
+
+[[package]]
+name = "tract-nnef"
+version = "0.20.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb872e9c8c156a8b5194f27ebaff5867f2b2edbc22a6f47dc7fcf2bb8b52473"
+dependencies = [
+ "byteorder",
+ "flate2",
+ "log",
+ "nom",
+ "tar",
+ "tract-core",
+ "walkdir",
+]
+
+[[package]]
+name = "tract-onnx"
+version = "0.20.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec4ba4a71a7eb6ab440bd0e525ea582fc339d938ff1cee91dbf38e0a59af277e"
+dependencies = [
+ "bytes",
+ "derive-new",
+ "log",
+ "memmap2",
+ "num-integer",
+ "prost",
+ "smallvec",
+ "tract-hir",
+ "tract-nnef",
+ "tract-onnx-opl",
+]
+
+[[package]]
+name = "tract-onnx-opl"
+version = "0.20.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5efd9ae10b507905ae6d1df7ec48f4dab77ab9605b1bd86275bb19997882267"
+dependencies = [
+ "getrandom 0.2.15",
+ "log",
+ "rand",
+ "rand_distr",
+ "rustfft",
+ "tract-nnef",
+]
+
+[[package]]
+name = "transpose"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad61aed86bc3faea4300c7aee358b4c6d0c8d6ccc36524c96e4c92ccf26e77e"
+dependencies = [
+ "num-integer",
+ "strength_reduce",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 0.2.12",
+ "httparse",
+ "log",
+ "rand",
+ "rustls",
+ "sha1",
+ "thiserror 1.0.69",
+ "url",
+ "utf-8",
+]
 
 [[package]]
 name = "tungstenite"
@@ -1343,7 +5058,7 @@ dependencies = [
  "log",
  "rand",
  "sha1",
- "thiserror",
+ "thiserror 1.0.69",
  "url",
  "utf-8",
 ]
@@ -1355,10 +5070,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "uint"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicase"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-ident"
@@ -1367,13 +5112,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
+name = "unicode-normalization"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
- "idna",
+ "idna 1.0.3",
  "percent-encoding",
 ]
 
@@ -1397,18 +5175,45 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+dependencies = [
+ "getrandom 0.2.15",
+ "serde",
+]
+
+[[package]]
+name = "uuid"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
 dependencies = [
  "getrandom 0.3.1",
+ "serde",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"
@@ -1442,7 +5247,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.21.0",
  "tokio-util",
  "tower-service",
  "tracing",
@@ -1485,8 +5290,21 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -1507,7 +5325,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1522,6 +5340,98 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web3"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5388522c899d1e1c96a4c307e3797e0f697ba7c77dd8e0e625ecba9dd0342937"
+dependencies = [
+ "arrayvec",
+ "base64 0.21.7",
+ "bytes",
+ "derive_more 0.99.19",
+ "ethabi",
+ "ethereum-types",
+ "futures",
+ "futures-timer",
+ "headers",
+ "hex",
+ "idna 0.4.0",
+ "jsonrpc-core",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "pin-project",
+ "reqwest",
+ "rlp",
+ "secp256k1",
+ "serde",
+ "serde_json",
+ "soketto",
+ "tiny-keccak",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "url",
+ "web3-async-native-tls",
+]
+
+[[package]]
+name = "web3-async-native-tls"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f6d8d1636b2627fe63518d5a9b38a569405d9c9bc665c43c9c341de57227ebb"
+dependencies = [
+ "native-tls",
+ "thiserror 1.0.69",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1531,12 +5441,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
 name = "windows-core"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1547,11 +5463,20 @@ checksum = "6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3"
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1560,7 +5485,22 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -1569,15 +5509,21 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1587,9 +5533,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1605,9 +5563,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1617,9 +5587,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1628,12 +5610,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "winnow"
+version = "0.6.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e90edd2ac1aa278a5c4599b1d89cf03074b610800f866d4026dc199d7929a28"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "wit-bindgen-rt"
 version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -1647,6 +5648,50 @@ name = "writeable"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
+name = "ws_stream_wasm"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7999f5f4217fe3818726b66257a4475f71e74ffd190776ad053fa159e50737f5"
+dependencies = [
+ "async_io_stream",
+ "futures",
+ "js-sys",
+ "log",
+ "pharos",
+ "rustc_version",
+ "send_wrapper 0.6.0",
+ "thiserror 1.0.69",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
+name = "xattr"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d65cbf2f12c15564212d48f4e3dfb87923d25d611f2aed18f4cb23f0413d89e"
+dependencies = [
+ "libc",
+ "rustix 1.0.2",
+]
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "yoke"
@@ -1668,7 +5713,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
  "synstructure",
 ]
 
@@ -1698,7 +5743,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1709,7 +5754,7 @@ checksum = "6352c01d0edd5db859a63e2605f4ea3183ddbd15e2c4a9e7d32184df75e4f154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1729,9 +5774,15 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
 name = "zerovec"
@@ -1752,5 +5803,54 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "zip"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+dependencies = [
+ "aes",
+ "byteorder",
+ "bzip2",
+ "constant_time_eq 0.1.5",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
+ "hmac",
+ "pbkdf2 0.11.0",
+ "sha1",
+ "time",
+ "zstd",
+]
+
+[[package]]
+name = "zstd"
+version = "0.11.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "5.0.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.14+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fb060d4926e4ac3a3ad15d864e99ceb5f343c6b34f5bd6d81ae6ed417311be5"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,9 @@ indexmap = "=2.1.0"
 # AI関連
 tract-onnx = "0.20"
 ndarray = "0.15"
+web3 = "0.19.0"
+ethers = "2.0.14"
+futures-util = "0.3.31"
 
 [dev-dependencies]
 criterion = "0.5"

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+web: ./target/release/shardx
+worker: ./target/release/shardx --worker

--- a/README.md
+++ b/README.md
@@ -75,10 +75,21 @@ cd ShardX
   <a href="https://railway.app/template/ShardX">
     <img src="https://railway.app/button.svg" alt="Deploy on Railway" height="44px" />
   </a>
-  <a href="https://vercel.com/new/clone?repository-url=https://github.com/enablerdao/ShardX">
-    <img src="https://vercel.com/button" alt="Deploy to Vercel" />
+  <a href="https://heroku.com/deploy?template=https://github.com/enablerdao/ShardX">
+    <img src="https://www.herokucdn.com/deploy/button.svg" alt="Deploy to Heroku" />
+  </a>
+  <a href="https://fly.io/launch/github/enablerdao/ShardX">
+    <img src="https://fly.io/static/images/brand/logo-mark-dark.svg" alt="Deploy to Fly.io" height="44px" />
   </a>
 </div>
+
+各プラットフォームの特徴:
+- **Render**: 無料プランあり、簡単なセットアップ、開発・テスト向け
+- **Railway**: 高速デプロイ、直感的なUI、開発・テスト向け
+- **Heroku**: 安定性と拡張性、PostgreSQL・Redis連携、本番環境向け
+- **Fly.io**: グローバル分散デプロイ、低レイテンシー、本番環境向け
+
+詳細は[マルチプラットフォームデプロイガイド](docs/deployment/multi-platform-deployment.md)を参照してください。
 
 
 詳細な手順は[クイックスタートガイド](docs/quickstart.md)や[Renderデプロイガイド](docs/deployment/render-free.md)を参照してください。

--- a/app.json
+++ b/app.json
@@ -4,45 +4,78 @@
   "repository": "https://github.com/enablerdao/ShardX",
   "logo": "https://raw.githubusercontent.com/enablerdao/ShardX/main/web/assets/logo.svg",
   "keywords": ["blockchain", "rust", "shardx", "dag", "proof-of-flow"],
-  "success_url": "/",
+  "website": "https://shardx.org",
+  "success_url": "/dashboard",
   "env": {
     "NODE_ID": {
       "description": "ノードの一意の識別子",
       "generator": "secret"
     },
     "PORT": {
-      "description": "アプリケーションが使用するポート",
+      "description": "APIが使用するポート",
       "value": "54868"
     },
-    "LOG_LEVEL": {
+    "P2P_PORT": {
+      "description": "P2P通信に使用するポート",
+      "value": "54867"
+    },
+    "RUST_LOG": {
       "description": "ログレベル (debug, info, warn, error)",
       "value": "info"
     },
     "INITIAL_SHARDS": {
       "description": "初期シャード数",
-      "value": "256"
+      "value": "32"
+    },
+    "DATA_DIR": {
+      "description": "データ保存ディレクトリ",
+      "value": "/app/data"
+    },
+    "REDIS_ENABLED": {
+      "description": "Redisを使用するかどうか",
+      "value": "true"
+    },
+    "WEB_ENABLED": {
+      "description": "Webインターフェースを有効にするかどうか",
+      "value": "true"
     }
   },
   "formation": {
     "web": {
       "quantity": 1,
-      "size": "standard-1x"
+      "size": "basic"
+    },
+    "worker": {
+      "quantity": 1,
+      "size": "basic"
     }
   },
   "addons": [
     {
-      "plan": "heroku-postgresql:hobby-dev"
+      "plan": "heroku-postgresql:hobby-dev",
+      "as": "DATABASE"
     },
     {
-      "plan": "heroku-redis:hobby-dev"
+      "plan": "heroku-redis:hobby-dev",
+      "as": "REDIS"
     }
   ],
   "buildpacks": [
     {
       "url": "https://github.com/emk/heroku-buildpack-rust"
+    },
+    {
+      "url": "heroku/nodejs"
     }
   ],
   "scripts": {
-    "postdeploy": "cargo run --bin init_db"
-  }
+    "postdeploy": "cargo run --bin init_db && cd web && npm install && npm run build"
+  },
+  "stack": "heroku-22",
+  "cron": [
+    {
+      "command": "./target/release/shardx --maintenance",
+      "schedule": "0 */6 * * *"
+    }
+  ]
 }

--- a/contracts/ethereum/ShardXBridge.sol
+++ b/contracts/ethereum/ShardXBridge.sol
@@ -1,0 +1,279 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/security/Pausable.sol";
+import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+
+/**
+ * @title ShardXBridge
+ * @dev イーサリアムとShardX間のアセット転送を可能にするブリッジコントラクト
+ */
+contract ShardXBridge is Ownable, Pausable, ReentrancyGuard {
+    using SafeERC20 for IERC20;
+
+    // イベント
+    event Deposit(address indexed token, address indexed from, string toShardXAddress, uint256 amount, bytes32 depositId);
+    event Withdrawal(address indexed token, address indexed to, uint256 amount, bytes32 withdrawalId);
+    event ValidatorAdded(address indexed validator);
+    event ValidatorRemoved(address indexed validator);
+    event ThresholdChanged(uint256 oldThreshold, uint256 newThreshold);
+
+    // 構造体
+    struct WithdrawalRequest {
+        address token;
+        address recipient;
+        uint256 amount;
+        uint256 timestamp;
+        mapping(address => bool) validatorApprovals;
+        uint256 approvalCount;
+        bool executed;
+    }
+
+    // マッピング
+    mapping(bytes32 => WithdrawalRequest) public withdrawalRequests;
+    mapping(address => bool) public validators;
+    mapping(address => bool) public supportedTokens;
+
+    // 状態変数
+    uint256 public validatorThreshold;
+    uint256 public validatorCount;
+    uint256 public withdrawalRequestCount;
+    uint256 public depositCount;
+
+    /**
+     * @dev コンストラクタ
+     * @param _initialValidators 初期バリデータのアドレス配列
+     * @param _threshold 必要な承認数の閾値
+     */
+    constructor(address[] memory _initialValidators, uint256 _threshold) {
+        require(_threshold > 0 && _threshold <= _initialValidators.length, "Invalid threshold");
+        
+        for (uint256 i = 0; i < _initialValidators.length; i++) {
+            require(_initialValidators[i] != address(0), "Invalid validator address");
+            validators[_initialValidators[i]] = true;
+        }
+        
+        validatorCount = _initialValidators.length;
+        validatorThreshold = _threshold;
+    }
+
+    /**
+     * @dev サポートするトークンを追加
+     * @param _token トークンのアドレス
+     */
+    function addSupportedToken(address _token) external onlyOwner {
+        require(_token != address(0), "Invalid token address");
+        require(!supportedTokens[_token], "Token already supported");
+        
+        supportedTokens[_token] = true;
+    }
+
+    /**
+     * @dev サポートするトークンを削除
+     * @param _token トークンのアドレス
+     */
+    function removeSupportedToken(address _token) external onlyOwner {
+        require(supportedTokens[_token], "Token not supported");
+        
+        supportedTokens[_token] = false;
+    }
+
+    /**
+     * @dev バリデータを追加
+     * @param _validator バリデータのアドレス
+     */
+    function addValidator(address _validator) external onlyOwner {
+        require(_validator != address(0), "Invalid validator address");
+        require(!validators[_validator], "Validator already exists");
+        
+        validators[_validator] = true;
+        validatorCount++;
+        
+        emit ValidatorAdded(_validator);
+    }
+
+    /**
+     * @dev バリデータを削除
+     * @param _validator バリデータのアドレス
+     */
+    function removeValidator(address _validator) external onlyOwner {
+        require(validators[_validator], "Validator does not exist");
+        require(validatorCount > validatorThreshold, "Cannot remove validator below threshold");
+        
+        validators[_validator] = false;
+        validatorCount--;
+        
+        emit ValidatorRemoved(_validator);
+    }
+
+    /**
+     * @dev 閾値を変更
+     * @param _newThreshold 新しい閾値
+     */
+    function changeThreshold(uint256 _newThreshold) external onlyOwner {
+        require(_newThreshold > 0 && _newThreshold <= validatorCount, "Invalid threshold");
+        
+        uint256 oldThreshold = validatorThreshold;
+        validatorThreshold = _newThreshold;
+        
+        emit ThresholdChanged(oldThreshold, _newThreshold);
+    }
+
+    /**
+     * @dev トークンをデポジットしてShardXに転送
+     * @param _token トークンのアドレス
+     * @param _amount 金額
+     * @param _toShardXAddress ShardXの宛先アドレス
+     */
+    function deposit(address _token, uint256 _amount, string calldata _toShardXAddress) 
+        external 
+        nonReentrant 
+        whenNotPaused 
+    {
+        require(supportedTokens[_token], "Token not supported");
+        require(_amount > 0, "Amount must be greater than 0");
+        require(bytes(_toShardXAddress).length > 0, "Invalid ShardX address");
+        
+        // トークンを転送
+        IERC20(_token).safeTransferFrom(msg.sender, address(this), _amount);
+        
+        // デポジットIDを生成
+        bytes32 depositId = keccak256(abi.encodePacked(
+            _token, 
+            msg.sender, 
+            _toShardXAddress, 
+            _amount, 
+            block.timestamp, 
+            depositCount
+        ));
+        
+        depositCount++;
+        
+        // イベントを発行
+        emit Deposit(_token, msg.sender, _toShardXAddress, _amount, depositId);
+    }
+
+    /**
+     * @dev 引き出しリクエストを作成（バリデータのみ）
+     * @param _withdrawalId 引き出しID
+     * @param _token トークンのアドレス
+     * @param _recipient 受取人のアドレス
+     * @param _amount 金額
+     */
+    function requestWithdrawal(
+        bytes32 _withdrawalId,
+        address _token,
+        address _recipient,
+        uint256 _amount
+    ) 
+        external 
+        nonReentrant 
+        whenNotPaused 
+    {
+        require(validators[msg.sender], "Not a validator");
+        require(supportedTokens[_token], "Token not supported");
+        require(_recipient != address(0), "Invalid recipient");
+        require(_amount > 0, "Amount must be greater than 0");
+        
+        // 新しい引き出しリクエストを作成
+        WithdrawalRequest storage request = withdrawalRequests[_withdrawalId];
+        
+        // 新しいリクエストの場合
+        if (request.timestamp == 0) {
+            request.token = _token;
+            request.recipient = _recipient;
+            request.amount = _amount;
+            request.timestamp = block.timestamp;
+            request.approvalCount = 0;
+            request.executed = false;
+            withdrawalRequestCount++;
+        } else {
+            // 既存のリクエストの場合、パラメータが一致することを確認
+            require(request.token == _token, "Token mismatch");
+            require(request.recipient == _recipient, "Recipient mismatch");
+            require(request.amount == _amount, "Amount mismatch");
+            require(!request.executed, "Already executed");
+        }
+        
+        // このバリデータがまだ承認していない場合
+        if (!request.validatorApprovals[msg.sender]) {
+            request.validatorApprovals[msg.sender] = true;
+            request.approvalCount++;
+            
+            // 閾値に達したら実行
+            if (request.approvalCount >= validatorThreshold && !request.executed) {
+                request.executed = true;
+                
+                // トークンを転送
+                IERC20(request.token).safeTransfer(request.recipient, request.amount);
+                
+                // イベントを発行
+                emit Withdrawal(request.token, request.recipient, request.amount, _withdrawalId);
+            }
+        }
+    }
+
+    /**
+     * @dev コントラクトを一時停止（緊急時用）
+     */
+    function pause() external onlyOwner {
+        _pause();
+    }
+
+    /**
+     * @dev コントラクトの一時停止を解除
+     */
+    function unpause() external onlyOwner {
+        _unpause();
+    }
+
+    /**
+     * @dev 引き出しリクエストの状態を取得
+     * @param _withdrawalId 引き出しID
+     * @return token トークンのアドレス
+     * @return recipient 受取人のアドレス
+     * @return amount 金額
+     * @return timestamp タイムスタンプ
+     * @return approvalCount 承認数
+     * @return executed 実行済みかどうか
+     */
+    function getWithdrawalRequest(bytes32 _withdrawalId) 
+        external 
+        view 
+        returns (
+            address token,
+            address recipient,
+            uint256 amount,
+            uint256 timestamp,
+            uint256 approvalCount,
+            bool executed
+        ) 
+    {
+        WithdrawalRequest storage request = withdrawalRequests[_withdrawalId];
+        return (
+            request.token,
+            request.recipient,
+            request.amount,
+            request.timestamp,
+            request.approvalCount,
+            request.executed
+        );
+    }
+
+    /**
+     * @dev バリデータの承認状態を確認
+     * @param _withdrawalId 引き出しID
+     * @param _validator バリデータのアドレス
+     * @return 承認済みかどうか
+     */
+    function isApprovedByValidator(bytes32 _withdrawalId, address _validator) 
+        external 
+        view 
+        returns (bool) 
+    {
+        return withdrawalRequests[_withdrawalId].validatorApprovals[_validator];
+    }
+}

--- a/docs/deployment/multi-platform-deployment.md
+++ b/docs/deployment/multi-platform-deployment.md
@@ -1,0 +1,147 @@
+# マルチプラットフォームデプロイガイド
+
+このガイドでは、ShardXを以下の主要なクラウドプラットフォームにデプロイする方法を説明します：
+
+- [Render](#render)
+- [Railway](#railway)
+- [Heroku](#heroku)
+
+各プラットフォームには、それぞれの特徴と利点があります。プロジェクトの要件に最も適したプラットフォームを選択してください。
+
+## Render
+
+[Render](https://render.com/)は、静的サイト、Webサービス、データベースなどを簡単にデプロイできるクラウドプラットフォームです。無料プランが利用可能で、ShardXの開発やテスト環境に最適です。
+
+### デプロイ手順
+
+1. [Renderアカウント](https://dashboard.render.com/register)を作成します
+2. 以下のボタンをクリックしてデプロイを開始します：
+
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/enablerdao/ShardX)
+
+3. デプロイが完了すると、以下のサービスが自動的に作成されます：
+   - `shardx-node`: ShardXのメインノード
+   - `shardx-web`: Webインターフェース
+   - `redis`: キャッシュとメッセージングに使用
+   - `shardx-worker`: バックグラウンド処理用ワーカー
+
+### 設定オプション
+
+Renderでは、`render.yaml`ファイルを通じて以下の設定が可能です：
+
+- シャード数の調整（`INITIAL_SHARDS`環境変数）
+- ログレベルの設定（`RUST_LOG`環境変数）
+- データ保存先の指定（`DATA_DIR`環境変数）
+
+詳細な設定については、[Renderのドキュメント](https://render.com/docs)を参照してください。
+
+## Railway
+
+[Railway](https://railway.app/)は、アプリケーションのデプロイと管理を簡素化するプラットフォームです。GitHubリポジトリと連携して、自動デプロイが可能です。
+
+### デプロイ手順
+
+1. [Railwayアカウント](https://railway.app/login)を作成します
+2. 以下のボタンをクリックしてデプロイを開始します：
+
+[![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/template/ShardX)
+
+3. デプロイが完了すると、以下のサービスが自動的に作成されます：
+   - ShardXノード
+   - Webインターフェース
+   - Redisインスタンス
+
+### 設定オプション
+
+Railwayでは、`railway.json`ファイルを通じて以下の設定が可能です：
+
+- サービスの定義と環境変数の設定
+- Redisなどのプラグインの追加
+- デプロイ設定のカスタマイズ
+
+詳細な設定については、[Railwayのドキュメント](https://docs.railway.app/)を参照してください。
+
+## Heroku
+
+[Heroku](https://www.heroku.com/)は、クラウドアプリケーションプラットフォームとして長い歴史を持ち、多くの開発者に利用されています。
+
+### デプロイ手順
+
+1. [Herokuアカウント](https://signup.heroku.com/)を作成します
+2. Heroku CLIをインストールします：
+   ```bash
+   curl https://cli-assets.heroku.com/install.sh | sh
+   ```
+
+3. ログインしてアプリを作成します：
+   ```bash
+   heroku login
+   heroku create shardx-app
+   ```
+
+4. GitリポジトリをHerokuにプッシュします：
+   ```bash
+   git push heroku main
+   ```
+
+または、以下のボタンをクリックして直接デプロイすることもできます：
+
+[![Deploy to Heroku](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/enablerdao/ShardX)
+
+### 設定オプション
+
+Herokuでは、以下のファイルを通じて設定が可能です：
+
+- `app.json`: アプリケーションの基本設定
+- `Procfile`: 実行するプロセスの定義
+- `heroku.yml`: Dockerコンテナを使用する場合の設定
+
+詳細な設定については、[Herokuのドキュメント](https://devcenter.heroku.com/categories/reference)を参照してください。
+
+## 共通の設定項目
+
+どのプラットフォームでも、以下の共通設定が可能です：
+
+| 環境変数 | 説明 | デフォルト値 |
+|---------|------|------------|
+| `NODE_ID` | ノードの一意の識別子 | プラットフォーム名_node |
+| `RUST_LOG` | ログレベル | info |
+| `INITIAL_SHARDS` | 初期シャード数 | 32 |
+| `DATA_DIR` | データ保存ディレクトリ | /app/data |
+| `REDIS_ENABLED` | Redisを使用するかどうか | true |
+| `WEB_ENABLED` | Webインターフェースを有効にするかどうか | true |
+
+## トラブルシューティング
+
+### Render
+
+- **問題**: デプロイ後にサービスが起動しない
+  **解決策**: ログを確認し、必要なリソースが不足していないか確認してください。無料プランではリソースに制限があります。
+
+### Railway
+
+- **問題**: サービス間の接続エラー
+  **解決策**: 環境変数が正しく設定されているか確認してください。特に`REDIS_URL`などの接続文字列を確認します。
+
+### Heroku
+
+- **問題**: ビルドエラー
+  **解決策**: `heroku logs --tail`コマンドでログを確認し、ビルドプロセスのエラーを特定してください。
+
+## パフォーマンスの最適化
+
+各プラットフォームでのパフォーマンスを最適化するためのヒント：
+
+1. **シャード数の調整**: 無料プランでは、シャード数を10-32程度に設定することをお勧めします
+2. **ログレベル**: 本番環境では`info`または`warn`に設定してください
+3. **永続ストレージ**: 重要なデータには、プラットフォームが提供する永続ストレージを使用してください
+
+## 次のステップ
+
+デプロイが完了したら、以下の手順でShardXの機能を確認できます：
+
+1. Webインターフェースにアクセスして、ダッシュボードを確認
+2. APIエンドポイントを使用して、トランザクションを作成
+3. パフォーマンスモニタリングを設定して、システムの動作を監視
+
+詳細については、[ShardXドキュメント](../README.md)を参照してください。

--- a/examples/advanced_chart_example.rs
+++ b/examples/advanced_chart_example.rs
@@ -1,0 +1,148 @@
+use chrono::{Utc, Duration};
+use std::collections::HashMap;
+use shardx::chart::{
+    ChartType, DataSeriesBuilder, ChartBuilder, ChartDataAggregator,
+    OHLCDataSeriesBuilder, OHLCChartBuilder, TimeFrame, ChartManager
+};
+
+fn main() {
+    // 現在時刻を取得
+    let now = Utc::now();
+    
+    // 価格データを作成
+    let price_data = vec![
+        (now, 100.0),
+        (now + Duration::hours(1), 105.0),
+        (now + Duration::hours(2), 103.0),
+        (now + Duration::hours(3), 107.0),
+        (now + Duration::hours(4), 110.0),
+        (now + Duration::hours(5), 108.0),
+        (now + Duration::hours(6), 112.0),
+        (now + Duration::hours(7), 115.0),
+        (now + Duration::hours(8), 113.0),
+        (now + Duration::hours(9), 118.0),
+        (now + Duration::hours(10), 120.0),
+        (now + Duration::hours(11), 123.0),
+        (now + Duration::hours(12), 121.0),
+        (now + Duration::hours(13), 125.0),
+        (now + Duration::hours(14), 128.0),
+        (now + Duration::hours(15), 130.0),
+        (now + Duration::hours(16), 133.0),
+        (now + Duration::hours(17), 131.0),
+        (now + Duration::hours(18), 135.0),
+        (now + Duration::hours(19), 138.0),
+        (now + Duration::hours(20), 140.0),
+        (now + Duration::hours(21), 137.0),
+        (now + Duration::hours(22), 142.0),
+        (now + Duration::hours(23), 145.0),
+    ];
+    
+    // OHLCデータを作成
+    let ohlc_data = vec![
+        (now, 100.0, 105.0, 99.0, 103.0, 1000.0),
+        (now + Duration::hours(4), 103.0, 110.0, 102.0, 108.0, 1200.0),
+        (now + Duration::hours(8), 108.0, 115.0, 107.0, 113.0, 1500.0),
+        (now + Duration::hours(12), 113.0, 125.0, 112.0, 121.0, 1800.0),
+        (now + Duration::hours(16), 121.0, 134.0, 120.0, 131.0, 2000.0),
+        (now + Duration::hours(20), 131.0, 142.0, 130.0, 140.0, 2200.0),
+    ];
+    
+    // 価格データシリーズを作成
+    let price_series = DataSeriesBuilder::new("price", "価格")
+        .with_color("#4285F4")
+        .with_line_style("solid")
+        .add_data_points(price_data)
+        .build();
+    
+    // 移動平均を計算
+    let ma_data = ChartDataAggregator::calculate_moving_average(&price_series.data_points, 5);
+    
+    // 移動平均データシリーズを作成
+    let ma_series = DataSeriesBuilder::new("ma", "5時間移動平均")
+        .with_color("#DB4437")
+        .with_line_style("dashed")
+        .add_data_points(ma_data.iter().map(|p| (p.timestamp, p.value)).collect())
+        .build();
+    
+    // ボリンジャーバンドを計算
+    let (middle_band, upper_band, lower_band) = ChartDataAggregator::calculate_bollinger_bands(
+        &price_series.data_points, 10, 2.0
+    );
+    
+    // ボリンジャーバンドのデータシリーズを作成
+    let middle_band_series = DataSeriesBuilder::new("middle_band", "中央バンド")
+        .with_color("#0F9D58")
+        .with_line_style("dotted")
+        .add_data_points(middle_band.iter().map(|p| (p.timestamp, p.value)).collect())
+        .build();
+    
+    let upper_band_series = DataSeriesBuilder::new("upper_band", "上部バンド")
+        .with_color("#F4B400")
+        .with_line_style("dotted")
+        .add_data_points(upper_band.iter().map(|p| (p.timestamp, p.value)).collect())
+        .build();
+    
+    let lower_band_series = DataSeriesBuilder::new("lower_band", "下部バンド")
+        .with_color("#F4B400")
+        .with_line_style("dotted")
+        .add_data_points(lower_band.iter().map(|p| (p.timestamp, p.value)).collect())
+        .build();
+    
+    // OHLCデータシリーズを作成
+    let ohlc_series = OHLCDataSeriesBuilder::new("ohlc", "OHLC")
+        .with_up_color("#0F9D58")
+        .with_down_color("#DB4437")
+        .add_data_points_with_volume(ohlc_data)
+        .build();
+    
+    // チャートを作成
+    let price_chart = ChartBuilder::new("price_chart", ChartType::Line, "価格チャート")
+        .with_subtitle("24時間の価格推移")
+        .with_x_axis_label("時間")
+        .with_y_axis_label("価格")
+        .with_size(800, 400)
+        .add_series(price_series)
+        .add_series(ma_series)
+        .build();
+    
+    let bollinger_chart = ChartBuilder::new("bollinger_chart", ChartType::Line, "ボリンジャーバンド")
+        .with_subtitle("10期間、標準偏差2.0")
+        .with_x_axis_label("時間")
+        .with_y_axis_label("価格")
+        .with_size(800, 400)
+        .add_series(middle_band_series)
+        .add_series(upper_band_series)
+        .add_series(lower_band_series)
+        .build();
+    
+    let ohlc_chart = OHLCChartBuilder::new("ohlc_chart", "OHLCチャート")
+        .with_subtitle("4時間足")
+        .with_x_axis_label("時間")
+        .with_y_axis_label("価格")
+        .with_size(800, 400)
+        .add_series(ohlc_series)
+        .build();
+    
+    // チャートマネージャーを作成
+    let mut chart_manager = ChartManager::new();
+    
+    // チャートを登録
+    chart_manager.create_chart(price_chart).unwrap();
+    chart_manager.create_chart(bollinger_chart).unwrap();
+    chart_manager.create_ohlc_chart(ohlc_chart).unwrap();
+    
+    // チャートをレンダリング
+    let price_chart_svg = chart_manager.render_chart("price_chart").unwrap();
+    let bollinger_chart_svg = chart_manager.render_chart("bollinger_chart").unwrap();
+    let ohlc_chart_svg = chart_manager.render_ohlc_chart("ohlc_chart").unwrap();
+    
+    // SVGをファイルに保存
+    std::fs::write("price_chart.svg", price_chart_svg).unwrap();
+    std::fs::write("bollinger_chart.svg", bollinger_chart_svg).unwrap();
+    std::fs::write("ohlc_chart.svg", ohlc_chart_svg).unwrap();
+    
+    println!("チャートが生成されました。");
+    println!("- price_chart.svg");
+    println!("- bollinger_chart.svg");
+    println!("- ohlc_chart.svg");
+}

--- a/examples/transaction_prediction_example.rs
+++ b/examples/transaction_prediction_example.rs
@@ -1,0 +1,216 @@
+use std::collections::HashMap;
+use chrono::{Utc, Duration};
+use shardx::ai::{
+    PredictionModelType, PredictionTarget, PredictionHorizon,
+    ModelConfig, EnhancedTransactionPredictor
+};
+use shardx::transaction::{Transaction, TransactionStatus};
+
+fn main() {
+    // テストトランザクションを作成
+    let transactions = create_test_transactions();
+    
+    println!("トランザクション数: {}", transactions.len());
+    
+    // モデル設定を作成
+    let model_config = ModelConfig {
+        model_type: PredictionModelType::Ensemble,
+        hyperparameters: HashMap::new(),
+        features: vec![
+            "amount".to_string(),
+            "fee".to_string(),
+            "hour_of_day".to_string(),
+            "day_of_week".to_string(),
+            "is_weekend".to_string(),
+        ],
+        training_period_days: 30,
+        prediction_horizon: PredictionHorizon::MediumTerm,
+        confidence_level: 0.95,
+    };
+    
+    // 予測器を作成
+    let mut predictor = EnhancedTransactionPredictor::new(model_config);
+    
+    // モデルを学習
+    println!("モデルを学習中...");
+    match predictor.train(&transactions) {
+        Ok(_) => println!("モデルの学習が完了しました"),
+        Err(e) => {
+            println!("モデルの学習に失敗しました: {:?}", e);
+            return;
+        }
+    }
+    
+    // 特徴量重要度を取得
+    println!("\n特徴量重要度:");
+    match predictor.get_feature_importance() {
+        Ok(features) => {
+            for feature in features {
+                println!("  {}: {:.4}", feature.name, feature.importance.unwrap_or(0.0));
+            }
+        },
+        Err(e) => println!("特徴量重要度の取得に失敗しました: {:?}", e),
+    }
+    
+    // トランザクション数の予測
+    println!("\nトランザクション数の予測:");
+    match predictor.predict(PredictionTarget::TransactionCount) {
+        Ok(result) => {
+            println!("  予測期間: {} から {}", 
+                result.start_time.format("%Y-%m-%d %H:%M"),
+                result.end_time.format("%Y-%m-%d %H:%M"));
+            
+            println!("  予測データポイント:");
+            for (i, point) in result.predictions.iter().enumerate() {
+                if i < 5 || i >= result.predictions.len() - 5 {
+                    println!("    {}: {:.2}", point.timestamp.format("%Y-%m-%d %H:%M"), point.value);
+                } else if i == 5 {
+                    println!("    ...");
+                }
+            }
+            
+            if let Some(lower) = &result.confidence_lower {
+                println!("  信頼区間下限 (最初と最後の5件):");
+                for (i, point) in lower.iter().enumerate() {
+                    if i < 5 || i >= lower.len() - 5 {
+                        println!("    {}: {:.2}", point.timestamp.format("%Y-%m-%d %H:%M"), point.value);
+                    } else if i == 5 {
+                        println!("    ...");
+                    }
+                }
+            }
+            
+            if let Some(upper) = &result.confidence_upper {
+                println!("  信頼区間上限 (最初と最後の5件):");
+                for (i, point) in upper.iter().enumerate() {
+                    if i < 5 || i >= upper.len() - 5 {
+                        println!("    {}: {:.2}", point.timestamp.format("%Y-%m-%d %H:%M"), point.value);
+                    } else if i == 5 {
+                        println!("    ...");
+                    }
+                }
+            }
+            
+            println!("  予測精度: {:.2}%", result.accuracy.unwrap_or(0.0) * 100.0);
+            println!("  RMSE: {:.4}", result.error_rmse.unwrap_or(0.0));
+            println!("  MAE: {:.4}", result.error_mae.unwrap_or(0.0));
+        },
+        Err(e) => println!("予測に失敗しました: {:?}", e),
+    }
+    
+    // 取引量の予測
+    println!("\n取引量の予測:");
+    match predictor.predict(PredictionTarget::TransactionVolume) {
+        Ok(result) => {
+            println!("  予測期間: {} から {}", 
+                result.start_time.format("%Y-%m-%d %H:%M"),
+                result.end_time.format("%Y-%m-%d %H:%M"));
+            
+            println!("  予測データポイント (最初と最後の5件):");
+            for (i, point) in result.predictions.iter().enumerate() {
+                if i < 5 || i >= result.predictions.len() - 5 {
+                    println!("    {}: {:.2}", point.timestamp.format("%Y-%m-%d %H:%M"), point.value);
+                } else if i == 5 {
+                    println!("    ...");
+                }
+            }
+            
+            println!("  予測精度: {:.2}%", result.accuracy.unwrap_or(0.0) * 100.0);
+        },
+        Err(e) => println!("予測に失敗しました: {:?}", e),
+    }
+    
+    // 手数料の予測
+    println!("\n手数料の予測:");
+    match predictor.predict(PredictionTarget::TransactionFee) {
+        Ok(result) => {
+            println!("  予測期間: {} から {}", 
+                result.start_time.format("%Y-%m-%d %H:%M"),
+                result.end_time.format("%Y-%m-%d %H:%M"));
+            
+            println!("  予測データポイント (最初と最後の5件):");
+            for (i, point) in result.predictions.iter().enumerate() {
+                if i < 5 || i >= result.predictions.len() - 5 {
+                    println!("    {}: {:.2}", point.timestamp.format("%Y-%m-%d %H:%M"), point.value);
+                } else if i == 5 {
+                    println!("    ...");
+                }
+            }
+            
+            println!("  予測精度: {:.2}%", result.accuracy.unwrap_or(0.0) * 100.0);
+        },
+        Err(e) => println!("予測に失敗しました: {:?}", e),
+    }
+    
+    // ネットワーク負荷の予測
+    println!("\nネットワーク負荷の予測:");
+    match predictor.predict(PredictionTarget::NetworkLoad) {
+        Ok(result) => {
+            println!("  予測期間: {} から {}", 
+                result.start_time.format("%Y-%m-%d %H:%M"),
+                result.end_time.format("%Y-%m-%d %H:%M"));
+            
+            println!("  予測データポイント (最初と最後の5件):");
+            for (i, point) in result.predictions.iter().enumerate() {
+                if i < 5 || i >= result.predictions.len() - 5 {
+                    println!("    {}: {:.2}%", point.timestamp.format("%Y-%m-%d %H:%M"), point.value);
+                } else if i == 5 {
+                    println!("    ...");
+                }
+            }
+            
+            println!("  予測精度: {:.2}%", result.accuracy.unwrap_or(0.0) * 100.0);
+        },
+        Err(e) => println!("予測に失敗しました: {:?}", e),
+    }
+}
+
+fn create_test_transactions() -> Vec<Transaction> {
+    let now = Utc::now();
+    let mut transactions = Vec::new();
+    
+    // 過去30日間のトランザクションを生成
+    for day in 0..30 {
+        // 1日あたり10〜50件のトランザクションを生成
+        let tx_count = 10 + (day % 5) * 10;
+        
+        for i in 0..tx_count {
+            let timestamp = now - Duration::days(30 - day) + Duration::hours(i as i64 % 24);
+            
+            // 時間帯による変動
+            let hour_factor = 1.0 + 0.5 * ((timestamp.hour() as f64 - 12.0).abs() / 12.0);
+            
+            // 曜日による変動
+            let weekday = timestamp.weekday().num_days_from_monday();
+            let day_factor = if weekday >= 5 { 0.7 } else { 1.3 };
+            
+            // 基本取引量
+            let base_amount = 100.0 * hour_factor * day_factor;
+            
+            // トレンド（日が経つにつれて増加）
+            let trend_factor = 1.0 + day as f64 / 30.0;
+            
+            // 最終的な取引量
+            let amount = (base_amount * trend_factor) as u64;
+            
+            // 手数料は取引量の約1%
+            let fee = (amount as f64 * 0.01) as u64;
+            
+            let transaction = Transaction {
+                id: format!("tx-{}-{}", day, i),
+                sender: format!("sender-{}", i % 100),
+                receiver: format!("receiver-{}", (i + 1) % 100),
+                amount,
+                fee,
+                timestamp: timestamp.timestamp(),
+                signature: None,
+                status: TransactionStatus::Confirmed,
+                data: None,
+            };
+            
+            transactions.push(transaction);
+        }
+    }
+    
+    transactions
+}

--- a/fly.toml
+++ b/fly.toml
@@ -6,10 +6,14 @@ primary_region = "nrt"
   dockerfile = "Dockerfile"
 
 [env]
-  PORT = "54868"
   NODE_ID = "fly_node"
-  LOG_LEVEL = "info"
-  INITIAL_SHARDS = "256"
+  RUST_LOG = "info"
+  INITIAL_SHARDS = "64"
+  DATA_DIR = "/app/data"
+  REDIS_ENABLED = "true"
+  WEB_ENABLED = "true"
+  PORT = "54868"
+  P2P_PORT = "54867"
 
 [http_service]
   internal_port = 54868
@@ -19,11 +23,44 @@ primary_region = "nrt"
   min_machines_running = 1
   processes = ["app"]
 
-[[vm]]
-  cpu_kind = "shared"
-  cpus = 1
-  memory_mb = 1024
+[services]
+  [services.web]
+    protocol = "tcp"
+    internal_port = 54868
+    processes = ["app"]
+
+    [[services.web.ports]]
+      port = 80
+      handlers = ["http"]
+      force_https = true
+
+    [[services.web.ports]]
+      port = 443
+      handlers = ["tls", "http"]
+
+    [services.web.concurrency]
+      type = "connections"
+      hard_limit = 1000
+      soft_limit = 500
+
+  [services.p2p]
+    protocol = "tcp"
+    internal_port = 54867
+    processes = ["app"]
+
+    [[services.p2p.ports]]
+      port = 54867
+      handlers = ["tcp"]
 
 [mounts]
   source = "shardx_data"
   destination = "/app/data"
+
+[metrics]
+  port = 9091
+  path = "/metrics"
+
+[[vm]]
+  memory = "1gb"
+  cpu_kind = "shared"
+  cpus = 1

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,0 +1,23 @@
+build:
+  docker:
+    web: Dockerfile
+    worker: Dockerfile
+  config:
+    INITIAL_SHARDS: 32
+
+run:
+  web: /app/shardx
+  worker: /app/shardx --worker
+
+setup:
+  addons:
+    - plan: heroku-postgresql:hobby-dev
+      as: DATABASE
+    - plan: heroku-redis:hobby-dev
+      as: REDIS
+  config:
+    NODE_ID: heroku_node
+    RUST_LOG: info
+    DATA_DIR: /app/data
+    REDIS_ENABLED: true
+    WEB_ENABLED: true

--- a/railway.json
+++ b/railway.json
@@ -9,5 +9,35 @@
     "startCommand": "/app/shardx",
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 10
-  }
+  },
+  "plugins": {
+    "redis": {
+      "image": "redis:7-alpine",
+      "envs": {
+        "REDIS_URL": "${REDIS_URL}"
+      }
+    }
+  },
+  "services": [
+    {
+      "name": "shardx-node",
+      "envs": {
+        "NODE_ID": "railway_node",
+        "RUST_LOG": "info",
+        "INITIAL_SHARDS": "64",
+        "DATA_DIR": "/app/data",
+        "PORT": "54868",
+        "P2P_PORT": "54867",
+        "REDIS_ENABLED": "true"
+      }
+    },
+    {
+      "name": "shardx-web",
+      "envs": {
+        "PORT": "52153",
+        "API_URL": "${RAILWAY_PUBLIC_DOMAIN}"
+      },
+      "startCommand": "cd web && npm start"
+    }
+  ]
 }

--- a/render.yaml
+++ b/render.yaml
@@ -18,6 +18,13 @@ services:
         value: "10" # シャード数を減らして軽量化
       - key: DATA_DIR
         value: /tmp/shardx-data # 一時ディレクトリを使用
+      - key: REDIS_ENABLED
+        value: "true"
+      - key: REDIS_URL
+        fromService:
+          name: redis
+          type: redis
+          property: connectionString
 
   # Webインターフェース（Node.js）
   - type: web
@@ -34,3 +41,35 @@ services:
         value: 52153
       - key: API_URL
         value: https://shardx-node.onrender.com
+      - key: NODE_ENV
+        value: production
+
+  # Redis（キャッシュとメッセージングに使用）
+  - type: redis
+    name: redis
+    ipAllowList: # 全てのIPからのアクセスを許可
+      - source: 0.0.0.0/0
+        description: everywhere
+    plan: free # 無料プラン
+
+  # バックグラウンドワーカー（分析処理用）
+  - type: worker
+    name: shardx-worker
+    env: docker
+    dockerfilePath: ./Dockerfile.simple
+    dockerContext: .
+    plan: free # 無料プラン
+    envVars:
+      - key: NODE_ID
+        value: render_worker
+      - key: RUST_LOG
+        value: info
+      - key: WORKER_MODE
+        value: "true"
+      - key: REDIS_ENABLED
+        value: "true"
+      - key: REDIS_URL
+        fromService:
+          name: redis
+          type: redis
+          property: connectionString

--- a/scripts/deploy-fly.sh
+++ b/scripts/deploy-fly.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+set -e
+
+# ShardXをFly.ioにデプロイするスクリプト
+
+# 色の定義
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+echo -e "${BLUE}=== ShardX Fly.ioデプロイスクリプト ===${NC}"
+echo
+
+# Fly CLIがインストールされているか確認
+if ! command -v flyctl &> /dev/null; then
+    echo -e "${RED}Fly CLIがインストールされていません。${NC}"
+    echo "インストール方法: curl -L https://fly.io/install.sh | sh"
+    
+    # インストールを試みる
+    read -p "Fly CLIをインストールしますか？ (y/n): " INSTALL_CLI
+    if [[ "$INSTALL_CLI" == "y" || "$INSTALL_CLI" == "Y" ]]; then
+        echo -e "${BLUE}Fly CLIをインストールしています...${NC}"
+        curl -L https://fly.io/install.sh | sh
+        
+        # PATHを更新
+        export PATH=$HOME/.fly/bin:$PATH
+    else
+        echo -e "${RED}Fly CLIが必要です。インストール後に再実行してください。${NC}"
+        exit 1
+    fi
+fi
+
+# ログイン状態を確認
+if ! flyctl auth whoami &> /dev/null; then
+    echo -e "${BLUE}Fly.ioにログインしてください...${NC}"
+    flyctl auth login
+fi
+
+# アプリ名を取得
+read -p "Fly.ioアプリ名を入力してください (例: shardx-app): " APP_NAME
+
+# リージョンを選択
+echo -e "${BLUE}デプロイするリージョンを選択してください:${NC}"
+echo "1) Tokyo (nrt)"
+echo "2) Singapore (sin)"
+echo "3) Los Angeles (lax)"
+echo "4) New York (ewr)"
+echo "5) London (lhr)"
+read -p "リージョン番号を選択してください (1-5): " REGION_NUM
+
+case $REGION_NUM in
+    1) REGION="nrt" ;;
+    2) REGION="sin" ;;
+    3) REGION="lax" ;;
+    4) REGION="ewr" ;;
+    5) REGION="lhr" ;;
+    *) REGION="nrt" ;;
+esac
+
+# fly.tomlを更新
+echo -e "${BLUE}設定ファイルを更新しています...${NC}"
+sed -i "s/app = \"shardx\"/app = \"$APP_NAME\"/" fly.toml
+sed -i "s/primary_region = \"nrt\"/primary_region = \"$REGION\"/" fly.toml
+
+# アプリを作成
+echo -e "${BLUE}Fly.ioアプリを作成しています...${NC}"
+flyctl apps create "$APP_NAME" --generate-name
+
+# ボリュームを作成
+echo -e "${BLUE}永続ボリュームを作成しています...${NC}"
+flyctl volumes create shardx_data --region "$REGION" --size 1 --app "$APP_NAME"
+
+# Redisを追加
+echo -e "${BLUE}Redisを追加しています...${NC}"
+flyctl redis create --name "${APP_NAME}-redis" --region "$REGION" --vm-size shared-cpu-1x --initial-cluster-size 1
+
+# Redisの接続情報を取得
+REDIS_URL=$(flyctl redis status "${APP_NAME}-redis" --json | jq -r '.url')
+flyctl secrets set REDIS_URL="$REDIS_URL" --app "$APP_NAME"
+
+# デプロイ
+echo -e "${BLUE}Fly.ioにデプロイしています...${NC}"
+flyctl deploy --app "$APP_NAME"
+
+# 完了
+echo -e "${GREEN}デプロイが完了しました！${NC}"
+echo -e "アプリURL: ${BLUE}https://$APP_NAME.fly.dev${NC}"
+echo
+echo -e "${BLUE}ログを確認するには:${NC} flyctl logs --app $APP_NAME"

--- a/scripts/deploy-heroku.sh
+++ b/scripts/deploy-heroku.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+set -e
+
+# ShardXをHerokuにデプロイするスクリプト
+
+# 色の定義
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+echo -e "${BLUE}=== ShardX Herokuデプロイスクリプト ===${NC}"
+echo
+
+# Heroku CLIがインストールされているか確認
+if ! command -v heroku &> /dev/null; then
+    echo -e "${RED}Heroku CLIがインストールされていません。${NC}"
+    echo "インストール方法: https://devcenter.heroku.com/articles/heroku-cli"
+    exit 1
+fi
+
+# ログイン状態を確認
+if ! heroku auth:whoami &> /dev/null; then
+    echo -e "${BLUE}Herokuにログインしてください...${NC}"
+    heroku login
+fi
+
+# アプリ名を取得
+read -p "Herokuアプリ名を入力してください (例: shardx-app): " APP_NAME
+
+# アプリが存在するか確認
+if heroku apps:info --app "$APP_NAME" &> /dev/null; then
+    echo -e "${BLUE}既存のアプリ '$APP_NAME' を使用します${NC}"
+else
+    echo -e "${BLUE}新しいアプリ '$APP_NAME' を作成します...${NC}"
+    heroku apps:create "$APP_NAME"
+fi
+
+# アドオンを追加
+echo -e "${BLUE}必要なアドオンを追加しています...${NC}"
+heroku addons:create heroku-postgresql:hobby-dev --app "$APP_NAME" || echo "PostgreSQLは既に追加されています"
+heroku addons:create heroku-redis:hobby-dev --app "$APP_NAME" || echo "Redisは既に追加されています"
+
+# 環境変数を設定
+echo -e "${BLUE}環境変数を設定しています...${NC}"
+heroku config:set NODE_ID="heroku_node_$(date +%s)" --app "$APP_NAME"
+heroku config:set RUST_LOG=info --app "$APP_NAME"
+heroku config:set INITIAL_SHARDS=32 --app "$APP_NAME"
+heroku config:set DATA_DIR=/app/data --app "$APP_NAME"
+heroku config:set REDIS_ENABLED=true --app "$APP_NAME"
+heroku config:set WEB_ENABLED=true --app "$APP_NAME"
+
+# スタックを設定
+heroku stack:set heroku-22 --app "$APP_NAME"
+
+# ビルドパックを設定
+echo -e "${BLUE}ビルドパックを設定しています...${NC}"
+heroku buildpacks:clear --app "$APP_NAME" || true
+heroku buildpacks:add https://github.com/emk/heroku-buildpack-rust --app "$APP_NAME"
+heroku buildpacks:add heroku/nodejs --app "$APP_NAME"
+
+# Herokuリモートを追加
+if ! git remote | grep -q heroku; then
+    echo -e "${BLUE}Herokuリモートを追加しています...${NC}"
+    heroku git:remote --app "$APP_NAME"
+fi
+
+# デプロイ
+echo -e "${BLUE}Herokuにデプロイしています...${NC}"
+echo "現在のブランチからデプロイします"
+git push heroku HEAD:main
+
+# スケーリング
+echo -e "${BLUE}プロセスをスケーリングしています...${NC}"
+heroku ps:scale web=1 worker=1 --app "$APP_NAME"
+
+# 完了
+echo -e "${GREEN}デプロイが完了しました！${NC}"
+echo -e "アプリURL: ${BLUE}https://$APP_NAME.herokuapp.com${NC}"
+echo -e "ダッシュボード: ${BLUE}https://dashboard.heroku.com/apps/$APP_NAME${NC}"
+echo
+echo -e "${BLUE}ログを確認するには:${NC} heroku logs --tail --app $APP_NAME"

--- a/scripts/deploy-railway.sh
+++ b/scripts/deploy-railway.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+set -e
+
+# ShardXをRailwayにデプロイするスクリプト
+
+# 色の定義
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+echo -e "${BLUE}=== ShardX Railwayデプロイスクリプト ===${NC}"
+echo
+
+# Railway CLIがインストールされているか確認
+if ! command -v railway &> /dev/null; then
+    echo -e "${RED}Railway CLIがインストールされていません。${NC}"
+    echo "インストール方法: npm i -g @railway/cli"
+    echo "または: curl -fsSL https://railway.app/install.sh | sh"
+    
+    # インストールを試みる
+    read -p "Railway CLIをインストールしますか？ (y/n): " INSTALL_CLI
+    if [[ "$INSTALL_CLI" == "y" || "$INSTALL_CLI" == "Y" ]]; then
+        echo -e "${BLUE}Railway CLIをインストールしています...${NC}"
+        curl -fsSL https://railway.app/install.sh | sh
+        
+        # PATHを更新
+        export PATH=$HOME/.railway/bin:$PATH
+    else
+        echo -e "${RED}Railway CLIが必要です。インストール後に再実行してください。${NC}"
+        exit 1
+    fi
+fi
+
+# ログイン状態を確認
+if ! railway whoami &> /dev/null; then
+    echo -e "${BLUE}Railwayにログインしてください...${NC}"
+    railway login
+fi
+
+# プロジェクト名を取得
+read -p "Railwayプロジェクト名を入力してください (例: shardx-app): " PROJECT_NAME
+
+# 新しいプロジェクトを作成するか確認
+read -p "新しいプロジェクトを作成しますか？ (y/n): " CREATE_PROJECT
+if [[ "$CREATE_PROJECT" == "y" || "$CREATE_PROJECT" == "Y" ]]; then
+    echo -e "${BLUE}新しいプロジェクト '$PROJECT_NAME' を作成します...${NC}"
+    railway project create "$PROJECT_NAME"
+fi
+
+# プロジェクトを選択
+echo -e "${BLUE}プロジェクトを選択してください...${NC}"
+railway link
+
+# 環境変数を設定
+echo -e "${BLUE}環境変数を設定しています...${NC}"
+railway variables set NODE_ID="railway_node_$(date +%s)"
+railway variables set RUST_LOG=info
+railway variables set INITIAL_SHARDS=64
+railway variables set DATA_DIR=/app/data
+railway variables set REDIS_ENABLED=true
+railway variables set WEB_ENABLED=true
+
+# デプロイ
+echo -e "${BLUE}Railwayにデプロイしています...${NC}"
+railway up
+
+# 完了
+echo -e "${GREEN}デプロイが完了しました！${NC}"
+echo -e "プロジェクトURL: ${BLUE}https://railway.app/project/$(railway project)${NC}"
+echo
+echo -e "${BLUE}ログを確認するには:${NC} railway logs"

--- a/scripts/deploy-render.sh
+++ b/scripts/deploy-render.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+set -e
+
+# ShardXをRenderにデプロイするスクリプト
+
+# 色の定義
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+echo -e "${BLUE}=== ShardX Renderデプロイスクリプト ===${NC}"
+echo
+
+# 必要なツールの確認
+if ! command -v curl &> /dev/null; then
+    echo -e "${RED}curlがインストールされていません。${NC}"
+    exit 1
+fi
+
+if ! command -v jq &> /dev/null; then
+    echo -e "${RED}jqがインストールされていません。${NC}"
+    echo "インストール方法: apt-get install jq または brew install jq"
+    exit 1
+fi
+
+# Renderのデプロイボタンを使用するためのURL
+REPO_URL="https://github.com/enablerdao/ShardX"
+RENDER_DEPLOY_URL="https://render.com/deploy?repo=$REPO_URL"
+
+echo -e "${BLUE}Renderへのデプロイを開始します...${NC}"
+echo -e "以下のURLをブラウザで開いてください:"
+echo -e "${GREEN}$RENDER_DEPLOY_URL${NC}"
+echo
+echo -e "${BLUE}ブラウザでRenderにログインし、デプロイボタンをクリックしてください。${NC}"
+echo -e "デプロイが完了すると、以下のサービスが自動的に作成されます:"
+echo "- shardx-node: ShardXのメインノード"
+echo "- shardx-web: Webインターフェース"
+echo "- redis: キャッシュとメッセージングに使用"
+echo "- shardx-worker: バックグラウンド処理用ワーカー"
+echo
+echo -e "${BLUE}ブラウザでURLを開きますか？ (y/n):${NC}"
+read -r OPEN_BROWSER
+
+if [[ "$OPEN_BROWSER" == "y" || "$OPEN_BROWSER" == "Y" ]]; then
+    if command -v xdg-open &> /dev/null; then
+        xdg-open "$RENDER_DEPLOY_URL"
+    elif command -v open &> /dev/null; then
+        open "$RENDER_DEPLOY_URL"
+    elif command -v start &> /dev/null; then
+        start "$RENDER_DEPLOY_URL"
+    else
+        echo -e "${RED}ブラウザを自動で開けませんでした。上記のURLを手動でブラウザにコピーしてください。${NC}"
+    fi
+fi
+
+echo
+echo -e "${BLUE}デプロイが完了したら、Renderダッシュボードでサービスの状態を確認してください。${NC}"
+echo -e "Renderダッシュボード: ${GREEN}https://dashboard.render.com/${NC}"

--- a/src/api/cross_chain_api.rs
+++ b/src/api/cross_chain_api.rs
@@ -1,0 +1,412 @@
+use std::sync::Arc;
+use warp::{Filter, Rejection, Reply};
+use serde::{Serialize, Deserialize};
+use log::{debug, info, warn, error};
+
+use crate::error::Error;
+use crate::cross_chain::{
+    bridge::{CrossChainBridge, BridgeConfig, ChainType, BridgeStatus},
+    transaction::{CrossChainTransaction, TransactionStatus},
+    token_registry::{TokenRegistry, TokenInfo},
+    enhanced_ethereum_bridge::EnhancedEthereumBridge,
+};
+
+/// クロスチェーンAPIハンドラ
+pub struct CrossChainApiHandler {
+    /// トークンレジストリ
+    token_registry: Arc<TokenRegistry>,
+    /// イーサリアムブリッジ
+    ethereum_bridge: Option<Arc<EnhancedEthereumBridge>>,
+}
+
+/// トークン転送リクエスト
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TokenTransferRequest {
+    /// トークンID
+    pub token_id: String,
+    /// 送信元アドレス（ShardXの場合）
+    pub from_address: Option<String>,
+    /// 送信先アドレス
+    pub to_address: String,
+    /// 金額
+    pub amount: String,
+    /// 送信元チェーン
+    pub source_chain: ChainType,
+    /// 送信先チェーン
+    pub target_chain: ChainType,
+}
+
+/// トークン転送レスポンス
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TokenTransferResponse {
+    /// トランザクションID
+    pub transaction_id: String,
+    /// ステータス
+    pub status: String,
+    /// メッセージ
+    pub message: String,
+}
+
+/// トランザクション状態リクエスト
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TransactionStatusRequest {
+    /// トランザクションID
+    pub transaction_id: String,
+}
+
+/// トランザクション状態レスポンス
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TransactionStatusResponse {
+    /// トランザクションID
+    pub transaction_id: String,
+    /// ステータス
+    pub status: String,
+    /// 送信元チェーン
+    pub source_chain: ChainType,
+    /// 送信先チェーン
+    pub target_chain: ChainType,
+    /// 送信元アドレス
+    pub from_address: String,
+    /// 送信先アドレス
+    pub to_address: String,
+    /// 金額
+    pub amount: String,
+    /// トークンシンボル
+    pub token_symbol: Option<String>,
+    /// 確認数
+    pub confirmations: Option<u64>,
+    /// 送信元ブロックハッシュ
+    pub source_block_hash: Option<String>,
+    /// 送信元ブロック高
+    pub source_block_height: Option<u64>,
+    /// 送信先ブロックハッシュ
+    pub target_block_hash: Option<String>,
+    /// 送信先ブロック高
+    pub target_block_height: Option<u64>,
+    /// タイムスタンプ
+    pub timestamp: u64,
+    /// エラーメッセージ
+    pub error_message: Option<String>,
+}
+
+/// サポートされているトークンレスポンス
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SupportedTokensResponse {
+    /// トークンリスト
+    pub tokens: Vec<TokenInfo>,
+}
+
+/// ブリッジ状態レスポンス
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BridgeStatusResponse {
+    /// ブリッジ状態
+    pub status: BridgeStatus,
+    /// サポートされているチェーン
+    pub supported_chains: Vec<ChainType>,
+}
+
+impl CrossChainApiHandler {
+    /// 新しいCrossChainApiHandlerを作成
+    pub fn new(
+        token_registry: Arc<TokenRegistry>,
+        ethereum_bridge: Option<Arc<EnhancedEthereumBridge>>,
+    ) -> Self {
+        Self {
+            token_registry,
+            ethereum_bridge,
+        }
+    }
+    
+    /// APIルートを作成
+    pub fn routes(&self) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+        let api_context = warp::any().map(move || self.clone());
+        
+        let transfer_route = warp::path!("api" / "v1" / "cross-chain" / "transfer")
+            .and(warp::post())
+            .and(warp::body::json())
+            .and(api_context.clone())
+            .and_then(Self::handle_transfer);
+        
+        let status_route = warp::path!("api" / "v1" / "cross-chain" / "status" / String)
+            .and(warp::get())
+            .and(api_context.clone())
+            .and_then(Self::handle_status);
+        
+        let tokens_route = warp::path!("api" / "v1" / "cross-chain" / "tokens")
+            .and(warp::get())
+            .and(api_context.clone())
+            .and_then(Self::handle_tokens);
+        
+        let bridge_status_route = warp::path!("api" / "v1" / "cross-chain" / "bridge-status")
+            .and(warp::get())
+            .and(api_context.clone())
+            .and_then(Self::handle_bridge_status);
+        
+        transfer_route
+            .or(status_route)
+            .or(tokens_route)
+            .or(bridge_status_route)
+    }
+    
+    /// トークン転送リクエストを処理
+    async fn handle_transfer(
+        request: TokenTransferRequest,
+        handler: Self,
+    ) -> Result<impl Reply, Rejection> {
+        info!("Handling cross-chain transfer request: {:?}", request);
+        
+        // リクエストを検証
+        if request.token_id.is_empty() {
+            return Ok(warp::reply::json(&TokenTransferResponse {
+                transaction_id: "".to_string(),
+                status: "error".to_string(),
+                message: "Token ID is required".to_string(),
+            }));
+        }
+        
+        if request.to_address.is_empty() {
+            return Ok(warp::reply::json(&TokenTransferResponse {
+                transaction_id: "".to_string(),
+                status: "error".to_string(),
+                message: "Recipient address is required".to_string(),
+            }));
+        }
+        
+        if request.amount.is_empty() {
+            return Ok(warp::reply::json(&TokenTransferResponse {
+                transaction_id: "".to_string(),
+                status: "error".to_string(),
+                message: "Amount is required".to_string(),
+            }));
+        }
+        
+        // トークン情報を取得
+        let token = match handler.token_registry.get_token(&request.token_id) {
+            Some(token) => token,
+            None => return Ok(warp::reply::json(&TokenTransferResponse {
+                transaction_id: "".to_string(),
+                status: "error".to_string(),
+                message: format!("Token not found: {}", request.token_id),
+            })),
+        };
+        
+        // チェーンタイプを検証
+        if token.chain_type != request.source_chain && token.chain_type != request.target_chain {
+            return Ok(warp::reply::json(&TokenTransferResponse {
+                transaction_id: "".to_string(),
+                status: "error".to_string(),
+                message: format!("Token {} is not on chain {} or {}", 
+                    token.symbol, request.source_chain, request.target_chain),
+            }));
+        }
+        
+        // トランザクションを作成
+        let transaction_id = match (request.source_chain, request.target_chain) {
+            (ChainType::ShardX, ChainType::Ethereum) => {
+                // ShardXからイーサリアムへの転送
+                let ethereum_bridge = match &handler.ethereum_bridge {
+                    Some(bridge) => bridge,
+                    None => return Ok(warp::reply::json(&TokenTransferResponse {
+                        transaction_id: "".to_string(),
+                        status: "error".to_string(),
+                        message: "Ethereum bridge not initialized".to_string(),
+                    })),
+                };
+                
+                let from_address = match request.from_address {
+                    Some(addr) => addr,
+                    None => return Ok(warp::reply::json(&TokenTransferResponse {
+                        transaction_id: "".to_string(),
+                        status: "error".to_string(),
+                        message: "From address is required for ShardX to Ethereum transfers".to_string(),
+                    })),
+                };
+                
+                match ethereum_bridge.transfer_to_ethereum(
+                    &request.token_id,
+                    &request.to_address,
+                    &request.amount,
+                    &from_address,
+                ).await {
+                    Ok(tx_id) => tx_id,
+                    Err(e) => return Ok(warp::reply::json(&TokenTransferResponse {
+                        transaction_id: "".to_string(),
+                        status: "error".to_string(),
+                        message: format!("Failed to create transaction: {}", e),
+                    })),
+                }
+            },
+            (ChainType::Ethereum, ChainType::ShardX) => {
+                // イーサリアムからShardXへの転送
+                let ethereum_bridge = match &handler.ethereum_bridge {
+                    Some(bridge) => bridge,
+                    None => return Ok(warp::reply::json(&TokenTransferResponse {
+                        transaction_id: "".to_string(),
+                        status: "error".to_string(),
+                        message: "Ethereum bridge not initialized".to_string(),
+                    })),
+                };
+                
+                match ethereum_bridge.transfer_from_ethereum(
+                    &request.token_id,
+                    &request.to_address,
+                    &request.amount,
+                ).await {
+                    Ok(tx_id) => tx_id,
+                    Err(e) => return Ok(warp::reply::json(&TokenTransferResponse {
+                        transaction_id: "".to_string(),
+                        status: "error".to_string(),
+                        message: format!("Failed to create transaction: {}", e),
+                    })),
+                }
+            },
+            _ => return Ok(warp::reply::json(&TokenTransferResponse {
+                transaction_id: "".to_string(),
+                status: "error".to_string(),
+                message: format!("Unsupported chain combination: {} -> {}", 
+                    request.source_chain, request.target_chain),
+            })),
+        };
+        
+        // 成功レスポンスを返す
+        Ok(warp::reply::json(&TokenTransferResponse {
+            transaction_id,
+            status: "success".to_string(),
+            message: format!("Transaction created successfully. Token: {}, Amount: {}", 
+                token.symbol, request.amount),
+        }))
+    }
+    
+    /// トランザクション状態リクエストを処理
+    async fn handle_status(
+        transaction_id: String,
+        handler: Self,
+    ) -> Result<impl Reply, Rejection> {
+        info!("Handling cross-chain transaction status request: {}", transaction_id);
+        
+        // トランザクションの状態を取得
+        let transaction_details = match handler.ethereum_bridge {
+            Some(ref bridge) => match bridge.get_transaction_details(&transaction_id) {
+                Ok(tx) => Some(tx),
+                Err(_) => None,
+            },
+            None => None,
+        };
+        
+        // トランザクションが見つからない場合
+        if transaction_details.is_none() {
+            return Ok(warp::reply::json(&TransactionStatusResponse {
+                transaction_id: transaction_id.clone(),
+                status: "not_found".to_string(),
+                source_chain: ChainType::Unknown,
+                target_chain: ChainType::Unknown,
+                from_address: "".to_string(),
+                to_address: "".to_string(),
+                amount: "0".to_string(),
+                token_symbol: None,
+                confirmations: None,
+                source_block_hash: None,
+                source_block_height: None,
+                target_block_hash: None,
+                target_block_height: None,
+                timestamp: 0,
+                error_message: Some("Transaction not found".to_string()),
+            }));
+        }
+        
+        // トランザクション詳細を取得
+        let tx = transaction_details.unwrap();
+        
+        // トークンシンボルを取得
+        let token_symbol = match tx.get_metadata("token_symbol") {
+            Some(symbol) => Some(symbol.to_string()),
+            None => {
+                // トークンIDからシンボルを取得
+                match tx.get_metadata("token_id") {
+                    Some(token_id) => {
+                        match handler.token_registry.get_token(token_id) {
+                            Some(token) => Some(token.symbol),
+                            None => None,
+                        }
+                    },
+                    None => None,
+                }
+            },
+        };
+        
+        // 確認数を取得
+        let confirmations = match tx.get_metadata("confirmations") {
+            Some(conf) => match conf.parse::<u64>() {
+                Ok(n) => Some(n),
+                Err(_) => None,
+            },
+            None => None,
+        };
+        
+        // レスポンスを作成
+        let response = TransactionStatusResponse {
+            transaction_id: tx.id.clone(),
+            status: tx.status.to_string(),
+            source_chain: tx.source_chain,
+            target_chain: tx.target_chain,
+            from_address: tx.transaction.from.clone(),
+            to_address: tx.transaction.to.clone(),
+            amount: tx.transaction.amount.clone(),
+            token_symbol,
+            confirmations,
+            source_block_hash: tx.source_block_hash.clone(),
+            source_block_height: tx.source_block_height,
+            target_block_hash: tx.target_block_hash.clone(),
+            target_block_height: tx.target_block_height,
+            timestamp: tx.transaction.timestamp,
+            error_message: tx.error_message.clone(),
+        };
+        
+        Ok(warp::reply::json(&response))
+    }
+    
+    /// サポートされているトークンリクエストを処理
+    async fn handle_tokens(
+        handler: Self,
+    ) -> Result<impl Reply, Rejection> {
+        info!("Handling supported tokens request");
+        
+        // すべてのトークンを取得
+        let tokens = handler.token_registry.get_all_tokens();
+        
+        // レスポンスを作成
+        let response = SupportedTokensResponse {
+            tokens,
+        };
+        
+        Ok(warp::reply::json(&response))
+    }
+    
+    /// ブリッジ状態リクエストを処理
+    async fn handle_bridge_status(
+        handler: Self,
+    ) -> Result<impl Reply, Rejection> {
+        info!("Handling bridge status request");
+        
+        // ブリッジ状態を取得
+        let status = match &handler.ethereum_bridge {
+            Some(bridge) => bridge.get_status(),
+            None => BridgeStatus::Offline,
+        };
+        
+        // サポートされているチェーンを取得
+        let mut supported_chains = vec![ChainType::ShardX];
+        
+        if handler.ethereum_bridge.is_some() {
+            supported_chains.push(ChainType::Ethereum);
+        }
+        
+        // レスポンスを作成
+        let response = BridgeStatusResponse {
+            status,
+            supported_chains,
+        };
+        
+        Ok(warp::reply::json(&response))
+    }
+}

--- a/src/bin/realistic_benchmark.rs
+++ b/src/bin/realistic_benchmark.rs
@@ -1,0 +1,769 @@
+use std::time::{Duration, Instant};
+use std::sync::{Arc, Mutex};
+use std::collections::HashMap;
+use std::thread;
+use std::fs::{File, OpenOptions};
+use std::io::{Write, Read, Seek, SeekFrom};
+use std::path::Path;
+use rand::{Rng, thread_rng, distributions::Distribution};
+use rand::distributions::{Normal, Uniform};
+use rand_distr::{Exp, Poisson};
+use rayon::prelude::*;
+use sha2::{Sha256, Digest};
+use ed25519_dalek::{Keypair, Signer, Verifier, PublicKey, SecretKey, Signature};
+use serde::{Serialize, Deserialize};
+use chrono::Utc;
+
+// トランザクション構造体
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Transaction {
+    id: String,
+    from: String,
+    to: String,
+    amount: u64,
+    fee: u64,
+    nonce: u64,
+    timestamp: u64,
+    data: Option<String>,
+    signature: Vec<u8>,
+}
+
+// ブロック構造体
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Block {
+    hash: String,
+    prev_hash: String,
+    height: u64,
+    timestamp: u64,
+    transactions: Vec<Transaction>,
+    merkle_root: String,
+    validator: String,
+    signature: Vec<u8>,
+}
+
+// シャード構造体
+#[derive(Debug)]
+struct Shard {
+    id: String,
+    transactions: Vec<Transaction>,
+    blocks: Vec<Block>,
+    accounts: HashMap<String, u64>,
+    pending_txs: Vec<Transaction>,
+    keypair: Keypair,
+}
+
+// ネットワーク遅延シミュレータ
+struct NetworkLatencySimulator {
+    base_latency_ms: f64,
+    jitter_ms: f64,
+    packet_loss_rate: f64,
+}
+
+// ディスクI/Oシミュレータ
+struct DiskIOSimulator {
+    read_latency_ms: f64,
+    write_latency_ms: f64,
+    sync_latency_ms: f64,
+    data_dir: String,
+}
+
+// コンセンサスシミュレータ
+struct ConsensusSimulator {
+    validation_time_ms: f64,
+    finality_time_ms: f64,
+    failure_rate: f64,
+}
+
+impl Transaction {
+    // 新しいトランザクションを作成
+    fn new(from: &str, to: &str, amount: u64, fee: u64, nonce: u64, keypair: &Keypair) -> Self {
+        let id = uuid::Uuid::new_v4().to_string();
+        let timestamp = Utc::now().timestamp() as u64;
+        
+        let mut tx = Self {
+            id,
+            from: from.to_string(),
+            to: to.to_string(),
+            amount,
+            fee,
+            nonce,
+            timestamp,
+            data: None,
+            signature: Vec::new(),
+        };
+        
+        // トランザクションに署名
+        tx.sign(keypair);
+        
+        tx
+    }
+    
+    // トランザクションに署名
+    fn sign(&mut self, keypair: &Keypair) {
+        let message = self.serialize_for_signing();
+        self.signature = keypair.sign(message.as_bytes()).to_bytes().to_vec();
+    }
+    
+    // 署名用のシリアライズ
+    fn serialize_for_signing(&self) -> String {
+        format!("{}:{}:{}:{}:{}:{}",
+            self.from, self.to, self.amount, self.fee, self.nonce, self.timestamp)
+    }
+    
+    // 署名を検証
+    fn verify_signature(&self, public_key: &PublicKey) -> bool {
+        let message = self.serialize_for_signing();
+        
+        if self.signature.len() != 64 {
+            return false;
+        }
+        
+        let signature = match Signature::from_bytes(&self.signature) {
+            Ok(sig) => sig,
+            Err(_) => return false,
+        };
+        
+        match public_key.verify(message.as_bytes(), &signature) {
+            Ok(_) => true,
+            Err(_) => false,
+        }
+    }
+}
+
+impl Block {
+    // 新しいブロックを作成
+    fn new(prev_hash: &str, height: u64, transactions: Vec<Transaction>, validator: &str, keypair: &Keypair) -> Self {
+        let timestamp = Utc::now().timestamp() as u64;
+        let merkle_root = Self::calculate_merkle_root(&transactions);
+        
+        let mut block = Self {
+            hash: String::new(),
+            prev_hash: prev_hash.to_string(),
+            height,
+            timestamp,
+            transactions,
+            merkle_root,
+            validator: validator.to_string(),
+            signature: Vec::new(),
+        };
+        
+        // ブロックハッシュを計算
+        block.calculate_hash();
+        
+        // ブロックに署名
+        block.sign(keypair);
+        
+        block
+    }
+    
+    // ブロックハッシュを計算
+    fn calculate_hash(&mut self) {
+        let data = format!("{}:{}:{}:{}:{}",
+            self.prev_hash, self.height, self.timestamp, self.merkle_root, self.validator);
+        
+        let mut hasher = Sha256::new();
+        hasher.update(data.as_bytes());
+        let result = hasher.finalize();
+        
+        self.hash = hex::encode(result);
+    }
+    
+    // マークルルートを計算
+    fn calculate_merkle_root(transactions: &[Transaction]) -> String {
+        if transactions.is_empty() {
+            return "0000000000000000000000000000000000000000000000000000000000000000".to_string();
+        }
+        
+        let mut hashes: Vec<String> = transactions.iter()
+            .map(|tx| {
+                let mut hasher = Sha256::new();
+                hasher.update(tx.id.as_bytes());
+                hex::encode(hasher.finalize())
+            })
+            .collect();
+        
+        while hashes.len() > 1 {
+            let mut new_hashes = Vec::new();
+            
+            for i in (0..hashes.len()).step_by(2) {
+                if i + 1 < hashes.len() {
+                    let mut hasher = Sha256::new();
+                    hasher.update(format!("{}{}", hashes[i], hashes[i + 1]).as_bytes());
+                    new_hashes.push(hex::encode(hasher.finalize()));
+                } else {
+                    new_hashes.push(hashes[i].clone());
+                }
+            }
+            
+            hashes = new_hashes;
+        }
+        
+        hashes[0].clone()
+    }
+    
+    // ブロックに署名
+    fn sign(&mut self, keypair: &Keypair) {
+        let message = self.hash.clone();
+        self.signature = keypair.sign(message.as_bytes()).to_bytes().to_vec();
+    }
+    
+    // 署名を検証
+    fn verify_signature(&self, public_key: &PublicKey) -> bool {
+        if self.signature.len() != 64 {
+            return false;
+        }
+        
+        let signature = match Signature::from_bytes(&self.signature) {
+            Ok(sig) => sig,
+            Err(_) => return false,
+        };
+        
+        match public_key.verify(self.hash.as_bytes(), &signature) {
+            Ok(_) => true,
+            Err(_) => false,
+        }
+    }
+}
+
+impl Shard {
+    // 新しいシャードを作成
+    fn new(id: &str) -> Self {
+        let mut csprng = rand::thread_rng();
+        let keypair = Keypair::generate(&mut csprng);
+        
+        let genesis_block = Block {
+            hash: "0000000000000000000000000000000000000000000000000000000000000000".to_string(),
+            prev_hash: "0000000000000000000000000000000000000000000000000000000000000000".to_string(),
+            height: 0,
+            timestamp: Utc::now().timestamp() as u64,
+            transactions: Vec::new(),
+            merkle_root: "0000000000000000000000000000000000000000000000000000000000000000".to_string(),
+            validator: id.to_string(),
+            signature: Vec::new(),
+        };
+        
+        Self {
+            id: id.to_string(),
+            transactions: Vec::new(),
+            blocks: vec![genesis_block],
+            accounts: HashMap::new(),
+            pending_txs: Vec::new(),
+            keypair,
+        }
+    }
+    
+    // アカウントを初期化
+    fn initialize_accounts(&mut self, num_accounts: usize, initial_balance: u64) {
+        for i in 0..num_accounts {
+            let address = format!("account_{}", i);
+            self.accounts.insert(address, initial_balance);
+        }
+    }
+    
+    // トランザクションを処理
+    fn process_transaction(&mut self, tx: &Transaction, network: &NetworkLatencySimulator, disk: &DiskIOSimulator) -> bool {
+        // ネットワーク遅延をシミュレート
+        network.simulate_latency();
+        
+        // 署名検証
+        let from_key_bytes = hex::decode("3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c").unwrap();
+        let public_key = PublicKey::from_bytes(&from_key_bytes).unwrap();
+        
+        if !tx.verify_signature(&public_key) {
+            return false;
+        }
+        
+        // 残高チェック
+        let sender_balance = *self.accounts.get(&tx.from).unwrap_or(&0);
+        if sender_balance < tx.amount + tx.fee {
+            return false;
+        }
+        
+        // トランザクションを実行
+        *self.accounts.get_mut(&tx.from).unwrap() -= tx.amount + tx.fee;
+        *self.accounts.entry(tx.to.clone()).or_insert(0) += tx.amount;
+        
+        // ディスクI/Oをシミュレート
+        disk.simulate_write();
+        
+        self.transactions.push(tx.clone());
+        true
+    }
+    
+    // ブロックを作成
+    fn create_block(&mut self, consensus: &ConsensusSimulator, disk: &DiskIOSimulator) -> Option<Block> {
+        if self.pending_txs.is_empty() {
+            return None;
+        }
+        
+        // コンセンサスをシミュレート
+        if !consensus.simulate_validation() {
+            return None;
+        }
+        
+        let max_txs = 1000;
+        let txs_to_include: Vec<Transaction> = self.pending_txs.drain(..std::cmp::min(max_txs, self.pending_txs.len())).collect();
+        
+        let prev_block = self.blocks.last().unwrap();
+        let new_block = Block::new(
+            &prev_block.hash,
+            prev_block.height + 1,
+            txs_to_include,
+            &self.id,
+            &self.keypair
+        );
+        
+        // ディスクI/Oをシミュレート
+        disk.simulate_write();
+        
+        // コンセンサスのファイナリティをシミュレート
+        consensus.simulate_finality();
+        
+        self.blocks.push(new_block.clone());
+        Some(new_block)
+    }
+}
+
+impl NetworkLatencySimulator {
+    // 新しいネットワーク遅延シミュレータを作成
+    fn new(base_latency_ms: f64, jitter_ms: f64, packet_loss_rate: f64) -> Self {
+        Self {
+            base_latency_ms,
+            jitter_ms,
+            packet_loss_rate,
+        }
+    }
+    
+    // ネットワーク遅延をシミュレート
+    fn simulate_latency(&self) {
+        let mut rng = thread_rng();
+        
+        // パケットロスをシミュレート
+        if rng.gen::<f64>() < self.packet_loss_rate {
+            // パケットロスが発生した場合、より長い遅延を追加
+            thread::sleep(Duration::from_millis((self.base_latency_ms * 5.0) as u64));
+            return;
+        }
+        
+        // 基本遅延 + ジッター
+        let normal = Normal::new(self.base_latency_ms, self.jitter_ms).unwrap();
+        let latency = normal.sample(&mut rng).max(0.0);
+        
+        thread::sleep(Duration::from_millis(latency as u64));
+    }
+}
+
+impl DiskIOSimulator {
+    // 新しいディスクI/Oシミュレータを作成
+    fn new(read_latency_ms: f64, write_latency_ms: f64, sync_latency_ms: f64, data_dir: &str) -> Self {
+        // データディレクトリを作成
+        std::fs::create_dir_all(data_dir).unwrap_or_default();
+        
+        Self {
+            read_latency_ms,
+            write_latency_ms,
+            sync_latency_ms,
+            data_dir: data_dir.to_string(),
+        }
+    }
+    
+    // 読み込み操作をシミュレート
+    fn simulate_read(&self) {
+        let mut rng = thread_rng();
+        let exp = Exp::new(1.0 / self.read_latency_ms).unwrap();
+        let latency = exp.sample(&mut rng);
+        
+        // 実際にファイルを読み込む
+        let file_path = Path::new(&self.data_dir).join("data.bin");
+        if file_path.exists() {
+            let mut file = File::open(file_path).unwrap_or_else(|_| {
+                File::create(Path::new(&self.data_dir).join("data.bin")).unwrap()
+            });
+            
+            let mut buffer = [0u8; 4096];
+            let _ = file.read(&mut buffer);
+        }
+        
+        thread::sleep(Duration::from_millis(latency as u64));
+    }
+    
+    // 書き込み操作をシミュレート
+    fn simulate_write(&self) {
+        let mut rng = thread_rng();
+        let exp = Exp::new(1.0 / self.write_latency_ms).unwrap();
+        let latency = exp.sample(&mut rng);
+        
+        // 実際にファイルに書き込む
+        let file_path = Path::new(&self.data_dir).join("data.bin");
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .append(true)
+            .open(file_path)
+            .unwrap();
+        
+        let data = [1u8; 4096];
+        let _ = file.write(&data);
+        
+        thread::sleep(Duration::from_millis(latency as u64));
+        
+        // fsyncをシミュレート
+        if rng.gen::<f64>() < 0.1 {  // 10%の確率でfsync
+            self.simulate_sync();
+        }
+    }
+    
+    // fsync操作をシミュレート
+    fn simulate_sync(&self) {
+        let mut rng = thread_rng();
+        let exp = Exp::new(1.0 / self.sync_latency_ms).unwrap();
+        let latency = exp.sample(&mut rng);
+        
+        // 実際にfsyncを呼び出す
+        let file_path = Path::new(&self.data_dir).join("data.bin");
+        if file_path.exists() {
+            let mut file = OpenOptions::new()
+                .write(true)
+                .open(file_path)
+                .unwrap();
+            
+            let _ = file.sync_all();
+        }
+        
+        thread::sleep(Duration::from_millis(latency as u64));
+    }
+}
+
+impl ConsensusSimulator {
+    // 新しいコンセンサスシミュレータを作成
+    fn new(validation_time_ms: f64, finality_time_ms: f64, failure_rate: f64) -> Self {
+        Self {
+            validation_time_ms,
+            finality_time_ms,
+            failure_rate,
+        }
+    }
+    
+    // 検証プロセスをシミュレート
+    fn simulate_validation(&self) -> bool {
+        let mut rng = thread_rng();
+        
+        // 検証失敗をシミュレート
+        if rng.gen::<f64>() < self.failure_rate {
+            // 失敗した場合でも時間はかかる
+            thread::sleep(Duration::from_millis(self.validation_time_ms as u64));
+            return false;
+        }
+        
+        // 検証時間をシミュレート
+        let exp = Exp::new(1.0 / self.validation_time_ms).unwrap();
+        let latency = exp.sample(&mut rng);
+        
+        thread::sleep(Duration::from_millis(latency as u64));
+        true
+    }
+    
+    // ファイナリティをシミュレート
+    fn simulate_finality(&self) {
+        let mut rng = thread_rng();
+        let exp = Exp::new(1.0 / self.finality_time_ms).unwrap();
+        let latency = exp.sample(&mut rng);
+        
+        thread::sleep(Duration::from_millis(latency as u64));
+    }
+}
+
+// ベンチマーク設定
+struct BenchmarkConfig {
+    num_shards: usize,
+    num_accounts_per_shard: usize,
+    initial_balance: u64,
+    num_transactions: usize,
+    transaction_rate: f64,  // 1秒あたりのトランザクション数
+    block_time_ms: u64,     // ブロック生成間隔（ミリ秒）
+    network_latency_ms: f64,
+    network_jitter_ms: f64,
+    packet_loss_rate: f64,
+    disk_read_latency_ms: f64,
+    disk_write_latency_ms: f64,
+    disk_sync_latency_ms: f64,
+    consensus_validation_time_ms: f64,
+    consensus_finality_time_ms: f64,
+    consensus_failure_rate: f64,
+}
+
+// ベンチマーク結果
+struct BenchmarkResult {
+    total_time_ms: u64,
+    transactions_processed: usize,
+    transactions_per_second: f64,
+    blocks_created: usize,
+    average_block_time_ms: f64,
+    average_transaction_latency_ms: f64,
+    failed_transactions: usize,
+    failure_rate: f64,
+}
+
+// ベンチマークを実行
+fn run_benchmark(config: &BenchmarkConfig) -> BenchmarkResult {
+    println!("Starting realistic benchmark with {} shards...", config.num_shards);
+    println!("Network latency: {}ms ± {}ms, Packet loss: {:.2}%", 
+        config.network_latency_ms, config.network_jitter_ms, config.packet_loss_rate * 100.0);
+    println!("Disk I/O: Read {}ms, Write {}ms, Sync {}ms", 
+        config.disk_read_latency_ms, config.disk_write_latency_ms, config.disk_sync_latency_ms);
+    println!("Consensus: Validation {}ms, Finality {}ms, Failure rate: {:.2}%",
+        config.consensus_validation_time_ms, config.consensus_finality_time_ms, config.consensus_failure_rate * 100.0);
+    
+    // シャードを初期化
+    let mut shards: Vec<Shard> = (0..config.num_shards)
+        .map(|i| {
+            let mut shard = Shard::new(&format!("shard_{}", i));
+            shard.initialize_accounts(config.num_accounts_per_shard, config.initial_balance);
+            shard
+        })
+        .collect();
+    
+    // シミュレータを初期化
+    let network = NetworkLatencySimulator::new(
+        config.network_latency_ms,
+        config.network_jitter_ms,
+        config.packet_loss_rate
+    );
+    
+    let disk = DiskIOSimulator::new(
+        config.disk_read_latency_ms,
+        config.disk_write_latency_ms,
+        config.disk_sync_latency_ms,
+        "benchmark_data"
+    );
+    
+    let consensus = ConsensusSimulator::new(
+        config.consensus_validation_time_ms,
+        config.consensus_finality_time_ms,
+        config.consensus_failure_rate
+    );
+    
+    // トランザクション生成間隔（マイクロ秒）
+    let tx_interval_us = (1_000_000.0 / config.transaction_rate) as u64;
+    
+    // ブロック生成間隔（マイクロ秒）
+    let block_interval_us = config.block_time_ms * 1000;
+    
+    // 統計情報
+    let transactions_processed = Arc::new(Mutex::new(0));
+    let failed_transactions = Arc::new(Mutex::new(0));
+    let blocks_created = Arc::new(Mutex::new(0));
+    let transaction_latencies = Arc::new(Mutex::new(Vec::new()));
+    
+    // ベンチマーク開始時間
+    let start_time = Instant::now();
+    
+    // トランザクション生成スレッド
+    let tx_processed = transactions_processed.clone();
+    let tx_failed = failed_transactions.clone();
+    let tx_latencies = transaction_latencies.clone();
+    let tx_thread = thread::spawn(move || {
+        let mut rng = thread_rng();
+        
+        for _ in 0..config.num_transactions {
+            let tx_start_time = Instant::now();
+            
+            // ランダムなシャードを選択
+            let shard_idx = rng.gen_range(0..config.num_shards);
+            let shard = &mut shards[shard_idx];
+            
+            // ランダムな送信元と送信先を選択
+            let from_idx = rng.gen_range(0..config.num_accounts_per_shard);
+            let to_idx = rng.gen_range(0..config.num_accounts_per_shard);
+            
+            let from = format!("account_{}", from_idx);
+            let to = format!("account_{}", to_idx);
+            
+            // ランダムな金額を選択（残高の1%〜10%）
+            let sender_balance = *shard.accounts.get(&from).unwrap_or(&0);
+            let amount = rng.gen_range((sender_balance / 100).max(1)..=(sender_balance / 10).max(1));
+            let fee = amount / 100;  // 手数料は金額の1%
+            
+            // トランザクションを作成
+            let tx = Transaction::new(&from, &to, amount, fee, rng.gen(), &shard.keypair);
+            
+            // トランザクションを処理
+            let success = shard.process_transaction(&tx, &network, &disk);
+            
+            if success {
+                shard.pending_txs.push(tx);
+                *tx_processed.lock().unwrap() += 1;
+                
+                // トランザクション処理時間を記録
+                let latency = tx_start_time.elapsed().as_millis() as u64;
+                tx_latencies.lock().unwrap().push(latency);
+            } else {
+                *tx_failed.lock().unwrap() += 1;
+            }
+            
+            // トランザクション生成間隔を待機
+            thread::sleep(Duration::from_micros(tx_interval_us));
+        }
+    });
+    
+    // ブロック生成スレッド
+    let blk_created = blocks_created.clone();
+    let block_thread = thread::spawn(move || {
+        let mut last_block_time = Instant::now();
+        
+        loop {
+            // 経過時間をチェック
+            let elapsed = last_block_time.elapsed();
+            if elapsed.as_micros() as u64 >= block_interval_us {
+                // 各シャードでブロックを生成
+                for shard in &mut shards {
+                    if let Some(_) = shard.create_block(&consensus, &disk) {
+                        *blk_created.lock().unwrap() += 1;
+                    }
+                }
+                
+                last_block_time = Instant::now();
+            }
+            
+            // すべてのトランザクションが処理されたかチェック
+            let processed = *transactions_processed.lock().unwrap();
+            let failed = *failed_transactions.lock().unwrap();
+            
+            if processed + failed >= config.num_transactions {
+                break;
+            }
+            
+            thread::sleep(Duration::from_millis(10));
+        }
+    });
+    
+    // スレッドの終了を待機
+    tx_thread.join().unwrap();
+    block_thread.join().unwrap();
+    
+    // 経過時間
+    let elapsed = start_time.elapsed();
+    let elapsed_ms = elapsed.as_millis() as u64;
+    
+    // 結果を集計
+    let transactions_processed = *transactions_processed.lock().unwrap();
+    let failed_transactions = *failed_transactions.lock().unwrap();
+    let blocks_created = *blocks_created.lock().unwrap();
+    let transaction_latencies = transaction_latencies.lock().unwrap().clone();
+    
+    let average_transaction_latency = if !transaction_latencies.is_empty() {
+        transaction_latencies.iter().sum::<u64>() as f64 / transaction_latencies.len() as f64
+    } else {
+        0.0
+    };
+    
+    let average_block_time = if blocks_created > 0 {
+        elapsed_ms as f64 / blocks_created as f64
+    } else {
+        0.0
+    };
+    
+    let tps = if elapsed_ms > 0 {
+        transactions_processed as f64 * 1000.0 / elapsed_ms as f64
+    } else {
+        0.0
+    };
+    
+    let failure_rate = if transactions_processed + failed_transactions > 0 {
+        failed_transactions as f64 / (transactions_processed + failed_transactions) as f64
+    } else {
+        0.0
+    };
+    
+    BenchmarkResult {
+        total_time_ms: elapsed_ms,
+        transactions_processed,
+        transactions_per_second: tps,
+        blocks_created,
+        average_block_time_ms: average_block_time,
+        average_transaction_latency_ms: average_transaction_latency,
+        failed_transactions,
+        failure_rate,
+    }
+}
+
+fn main() {
+    // ベンチマーク設定
+    let config = BenchmarkConfig {
+        num_shards: 10,
+        num_accounts_per_shard: 1000,
+        initial_balance: 1_000_000,
+        num_transactions: 100_000,
+        transaction_rate: 10_000.0,  // 1秒あたり10,000トランザクション
+        block_time_ms: 500,          // 500ミリ秒ごとにブロックを生成
+        network_latency_ms: 10.0,    // 平均10ミリ秒のネットワーク遅延
+        network_jitter_ms: 5.0,      // 5ミリ秒のジッター
+        packet_loss_rate: 0.01,      // 1%のパケットロス
+        disk_read_latency_ms: 1.0,   // 平均1ミリ秒の読み込み遅延
+        disk_write_latency_ms: 5.0,  // 平均5ミリ秒の書き込み遅延
+        disk_sync_latency_ms: 20.0,  // 平均20ミリ秒のfsync遅延
+        consensus_validation_time_ms: 50.0,  // 平均50ミリ秒の検証時間
+        consensus_finality_time_ms: 200.0,   // 平均200ミリ秒のファイナリティ時間
+        consensus_failure_rate: 0.005,       // 0.5%の検証失敗率
+    };
+    
+    // ベンチマークを実行
+    let result = run_benchmark(&config);
+    
+    // 結果を表示
+    println!("\nBenchmark Results:");
+    println!("Total time: {:.2} seconds", result.total_time_ms as f64 / 1000.0);
+    println!("Transactions processed: {}", result.transactions_processed);
+    println!("Transactions per second (TPS): {:.2}", result.transactions_per_second);
+    println!("Blocks created: {}", result.blocks_created);
+    println!("Average block time: {:.2} ms", result.average_block_time_ms);
+    println!("Average transaction latency: {:.2} ms", result.average_transaction_latency_ms);
+    println!("Failed transactions: {} ({:.2}%)", 
+        result.failed_transactions, result.failure_rate * 100.0);
+    
+    // 異なる設定でのベンチマーク
+    println!("\nRunning benchmark with different configurations...");
+    
+    // 1. 高負荷環境（高いトランザクションレート、高いネットワーク遅延）
+    let high_load_config = BenchmarkConfig {
+        transaction_rate: 50_000.0,  // 1秒あたり50,000トランザクション
+        network_latency_ms: 50.0,    // 平均50ミリ秒のネットワーク遅延
+        network_jitter_ms: 20.0,     // 20ミリ秒のジッター
+        ..config
+    };
+    
+    println!("\nHigh Load Configuration:");
+    let high_load_result = run_benchmark(&high_load_config);
+    println!("TPS: {:.2}", high_load_result.transactions_per_second);
+    
+    // 2. 最適環境（低いネットワーク遅延、高速なディスクI/O）
+    let optimal_config = BenchmarkConfig {
+        network_latency_ms: 1.0,     // 平均1ミリ秒のネットワーク遅延
+        network_jitter_ms: 0.5,      // 0.5ミリ秒のジッター
+        disk_read_latency_ms: 0.1,   // 平均0.1ミリ秒の読み込み遅延
+        disk_write_latency_ms: 0.5,  // 平均0.5ミリ秒の書き込み遅延
+        disk_sync_latency_ms: 2.0,   // 平均2ミリ秒のfsync遅延
+        ..config
+    };
+    
+    println!("\nOptimal Configuration:");
+    let optimal_result = run_benchmark(&optimal_config);
+    println!("TPS: {:.2}", optimal_result.transactions_per_second);
+    
+    // 3. 多シャード環境
+    let multi_shard_config = BenchmarkConfig {
+        num_shards: 100,  // 100シャード
+        ..config
+    };
+    
+    println!("\nMulti-Shard Configuration (100 shards):");
+    let multi_shard_result = run_benchmark(&multi_shard_config);
+    println!("TPS: {:.2}", multi_shard_result.transactions_per_second);
+    
+    // 結果の比較
+    println!("\nComparison of TPS across configurations:");
+    println!("Default: {:.2} TPS", result.transactions_per_second);
+    println!("High Load: {:.2} TPS", high_load_result.transactions_per_second);
+    println!("Optimal: {:.2} TPS", optimal_result.transactions_per_second);
+    println!("Multi-Shard: {:.2} TPS", multi_shard_result.transactions_per_second);
+}

--- a/src/chart/advanced_chart.rs
+++ b/src/chart/advanced_chart.rs
@@ -1,0 +1,1590 @@
+use std::collections::HashMap;
+use chrono::{DateTime, Utc, Duration};
+use serde::{Serialize, Deserialize};
+use log::{debug, error, info, warn};
+
+use crate::error::Error;
+use crate::transaction::{Transaction, TransactionStatus};
+use crate::shard::ShardId;
+
+/// チャートタイプ
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum ChartType {
+    /// 折れ線グラフ
+    Line,
+    /// 棒グラフ
+    Bar,
+    /// 円グラフ
+    Pie,
+    /// エリアチャート
+    Area,
+    /// キャンドルスティック
+    Candlestick,
+    /// ヒートマップ
+    Heatmap,
+    /// 散布図
+    Scatter,
+    /// レーダーチャート
+    Radar,
+}
+
+/// 時間枠
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum TimeFrame {
+    /// 分単位
+    Minute(u32),
+    /// 時間単位
+    Hour(u32),
+    /// 日単位
+    Day(u32),
+    /// 週単位
+    Week(u32),
+    /// 月単位
+    Month(u32),
+}
+
+impl TimeFrame {
+    /// 秒数に変換
+    pub fn to_seconds(&self) -> i64 {
+        match self {
+            TimeFrame::Minute(n) => *n as i64 * 60,
+            TimeFrame::Hour(n) => *n as i64 * 3600,
+            TimeFrame::Day(n) => *n as i64 * 86400,
+            TimeFrame::Week(n) => *n as i64 * 604800,
+            TimeFrame::Month(n) => *n as i64 * 2592000, // 30日で計算
+        }
+    }
+    
+    /// 文字列表現を取得
+    pub fn to_string(&self) -> String {
+        match self {
+            TimeFrame::Minute(n) => format!("{}分", n),
+            TimeFrame::Hour(n) => format!("{}時間", n),
+            TimeFrame::Day(n) => format!("{}日", n),
+            TimeFrame::Week(n) => format!("{}週間", n),
+            TimeFrame::Month(n) => format!("{}ヶ月", n),
+        }
+    }
+    
+    /// 期間内の時間枠の数を計算
+    pub fn count_in_range(&self, start: DateTime<Utc>, end: DateTime<Utc>) -> usize {
+        let duration = end.signed_duration_since(start).num_seconds();
+        let frame_seconds = self.to_seconds();
+        
+        (duration / frame_seconds) as usize + 1
+    }
+}
+
+/// データポイント
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DataPoint {
+    /// タイムスタンプ
+    pub timestamp: DateTime<Utc>,
+    /// 値
+    pub value: f64,
+    /// メタデータ
+    pub metadata: Option<HashMap<String, String>>,
+}
+
+/// OHLC（始値・高値・安値・終値）データポイント
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OHLCDataPoint {
+    /// タイムスタンプ
+    pub timestamp: DateTime<Utc>,
+    /// 始値
+    pub open: f64,
+    /// 高値
+    pub high: f64,
+    /// 安値
+    pub low: f64,
+    /// 終値
+    pub close: f64,
+    /// 出来高
+    pub volume: Option<f64>,
+    /// メタデータ
+    pub metadata: Option<HashMap<String, String>>,
+}
+
+/// チャートデータシリーズ
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DataSeries {
+    /// シリーズID
+    pub id: String,
+    /// シリーズ名
+    pub name: String,
+    /// データポイント
+    pub data_points: Vec<DataPoint>,
+    /// 色
+    pub color: Option<String>,
+    /// 線のスタイル
+    pub line_style: Option<String>,
+    /// マーカーのスタイル
+    pub marker_style: Option<String>,
+    /// メタデータ
+    pub metadata: Option<HashMap<String, String>>,
+}
+
+/// OHLCデータシリーズ
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OHLCDataSeries {
+    /// シリーズID
+    pub id: String,
+    /// シリーズ名
+    pub name: String,
+    /// OHLCデータポイント
+    pub data_points: Vec<OHLCDataPoint>,
+    /// 上昇色
+    pub up_color: Option<String>,
+    /// 下降色
+    pub down_color: Option<String>,
+    /// メタデータ
+    pub metadata: Option<HashMap<String, String>>,
+}
+
+/// チャート設定
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChartConfig {
+    /// チャートID
+    pub id: String,
+    /// チャートタイプ
+    pub chart_type: ChartType,
+    /// タイトル
+    pub title: String,
+    /// サブタイトル
+    pub subtitle: Option<String>,
+    /// X軸ラベル
+    pub x_axis_label: Option<String>,
+    /// Y軸ラベル
+    pub y_axis_label: Option<String>,
+    /// 凡例の表示
+    pub show_legend: bool,
+    /// グリッドの表示
+    pub show_grid: bool,
+    /// ツールチップの表示
+    pub show_tooltip: bool,
+    /// アニメーションの有効化
+    pub enable_animation: bool,
+    /// ズームの有効化
+    pub enable_zoom: bool,
+    /// エクスポートの有効化
+    pub enable_export: bool,
+    /// テーマ
+    pub theme: Option<String>,
+    /// 幅
+    pub width: Option<u32>,
+    /// 高さ
+    pub height: Option<u32>,
+    /// マージン
+    pub margin: Option<ChartMargin>,
+    /// メタデータ
+    pub metadata: Option<HashMap<String, String>>,
+}
+
+/// チャートマージン
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChartMargin {
+    /// 上
+    pub top: u32,
+    /// 右
+    pub right: u32,
+    /// 下
+    pub bottom: u32,
+    /// 左
+    pub left: u32,
+}
+
+/// チャート
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Chart {
+    /// 設定
+    pub config: ChartConfig,
+    /// データシリーズ
+    pub series: Vec<DataSeries>,
+    /// 作成時刻
+    pub created_at: DateTime<Utc>,
+    /// 更新時刻
+    pub updated_at: DateTime<Utc>,
+}
+
+/// OHLCチャート
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OHLCChart {
+    /// 設定
+    pub config: ChartConfig,
+    /// OHLCデータシリーズ
+    pub series: Vec<OHLCDataSeries>,
+    /// 作成時刻
+    pub created_at: DateTime<Utc>,
+    /// 更新時刻
+    pub updated_at: DateTime<Utc>,
+}
+
+/// チャートビルダー
+pub struct ChartBuilder {
+    /// 設定
+    config: ChartConfig,
+    /// データシリーズ
+    series: Vec<DataSeries>,
+}
+
+impl ChartBuilder {
+    /// 新しいチャートビルダーを作成
+    pub fn new(id: &str, chart_type: ChartType, title: &str) -> Self {
+        let config = ChartConfig {
+            id: id.to_string(),
+            chart_type,
+            title: title.to_string(),
+            subtitle: None,
+            x_axis_label: None,
+            y_axis_label: None,
+            show_legend: true,
+            show_grid: true,
+            show_tooltip: true,
+            enable_animation: true,
+            enable_zoom: true,
+            enable_export: true,
+            theme: None,
+            width: None,
+            height: None,
+            margin: None,
+            metadata: None,
+        };
+        
+        Self {
+            config,
+            series: Vec::new(),
+        }
+    }
+    
+    /// サブタイトルを設定
+    pub fn with_subtitle(mut self, subtitle: &str) -> Self {
+        self.config.subtitle = Some(subtitle.to_string());
+        self
+    }
+    
+    /// X軸ラベルを設定
+    pub fn with_x_axis_label(mut self, label: &str) -> Self {
+        self.config.x_axis_label = Some(label.to_string());
+        self
+    }
+    
+    /// Y軸ラベルを設定
+    pub fn with_y_axis_label(mut self, label: &str) -> Self {
+        self.config.y_axis_label = Some(label.to_string());
+        self
+    }
+    
+    /// 凡例の表示を設定
+    pub fn with_legend(mut self, show: bool) -> Self {
+        self.config.show_legend = show;
+        self
+    }
+    
+    /// グリッドの表示を設定
+    pub fn with_grid(mut self, show: bool) -> Self {
+        self.config.show_grid = show;
+        self
+    }
+    
+    /// ツールチップの表示を設定
+    pub fn with_tooltip(mut self, show: bool) -> Self {
+        self.config.show_tooltip = show;
+        self
+    }
+    
+    /// アニメーションの有効化を設定
+    pub fn with_animation(mut self, enable: bool) -> Self {
+        self.config.enable_animation = enable;
+        self
+    }
+    
+    /// ズームの有効化を設定
+    pub fn with_zoom(mut self, enable: bool) -> Self {
+        self.config.enable_zoom = enable;
+        self
+    }
+    
+    /// エクスポートの有効化を設定
+    pub fn with_export(mut self, enable: bool) -> Self {
+        self.config.enable_export = enable;
+        self
+    }
+    
+    /// テーマを設定
+    pub fn with_theme(mut self, theme: &str) -> Self {
+        self.config.theme = Some(theme.to_string());
+        self
+    }
+    
+    /// サイズを設定
+    pub fn with_size(mut self, width: u32, height: u32) -> Self {
+        self.config.width = Some(width);
+        self.config.height = Some(height);
+        self
+    }
+    
+    /// マージンを設定
+    pub fn with_margin(mut self, top: u32, right: u32, bottom: u32, left: u32) -> Self {
+        self.config.margin = Some(ChartMargin {
+            top,
+            right,
+            bottom,
+            left,
+        });
+        self
+    }
+    
+    /// メタデータを設定
+    pub fn with_metadata(mut self, metadata: HashMap<String, String>) -> Self {
+        self.config.metadata = Some(metadata);
+        self
+    }
+    
+    /// データシリーズを追加
+    pub fn add_series(mut self, series: DataSeries) -> Self {
+        self.series.push(series);
+        self
+    }
+    
+    /// チャートを構築
+    pub fn build(self) -> Chart {
+        let now = Utc::now();
+        
+        Chart {
+            config: self.config,
+            series: self.series,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+}
+
+/// OHLCチャートビルダー
+pub struct OHLCChartBuilder {
+    /// 設定
+    config: ChartConfig,
+    /// OHLCデータシリーズ
+    series: Vec<OHLCDataSeries>,
+}
+
+impl OHLCChartBuilder {
+    /// 新しいOHLCチャートビルダーを作成
+    pub fn new(id: &str, title: &str) -> Self {
+        let config = ChartConfig {
+            id: id.to_string(),
+            chart_type: ChartType::Candlestick,
+            title: title.to_string(),
+            subtitle: None,
+            x_axis_label: None,
+            y_axis_label: None,
+            show_legend: true,
+            show_grid: true,
+            show_tooltip: true,
+            enable_animation: true,
+            enable_zoom: true,
+            enable_export: true,
+            theme: None,
+            width: None,
+            height: None,
+            margin: None,
+            metadata: None,
+        };
+        
+        Self {
+            config,
+            series: Vec::new(),
+        }
+    }
+    
+    /// サブタイトルを設定
+    pub fn with_subtitle(mut self, subtitle: &str) -> Self {
+        self.config.subtitle = Some(subtitle.to_string());
+        self
+    }
+    
+    /// X軸ラベルを設定
+    pub fn with_x_axis_label(mut self, label: &str) -> Self {
+        self.config.x_axis_label = Some(label.to_string());
+        self
+    }
+    
+    /// Y軸ラベルを設定
+    pub fn with_y_axis_label(mut self, label: &str) -> Self {
+        self.config.y_axis_label = Some(label.to_string());
+        self
+    }
+    
+    /// 凡例の表示を設定
+    pub fn with_legend(mut self, show: bool) -> Self {
+        self.config.show_legend = show;
+        self
+    }
+    
+    /// グリッドの表示を設定
+    pub fn with_grid(mut self, show: bool) -> Self {
+        self.config.show_grid = show;
+        self
+    }
+    
+    /// ツールチップの表示を設定
+    pub fn with_tooltip(mut self, show: bool) -> Self {
+        self.config.show_tooltip = show;
+        self
+    }
+    
+    /// アニメーションの有効化を設定
+    pub fn with_animation(mut self, enable: bool) -> Self {
+        self.config.enable_animation = enable;
+        self
+    }
+    
+    /// ズームの有効化を設定
+    pub fn with_zoom(mut self, enable: bool) -> Self {
+        self.config.enable_zoom = enable;
+        self
+    }
+    
+    /// エクスポートの有効化を設定
+    pub fn with_export(mut self, enable: bool) -> Self {
+        self.config.enable_export = enable;
+        self
+    }
+    
+    /// テーマを設定
+    pub fn with_theme(mut self, theme: &str) -> Self {
+        self.config.theme = Some(theme.to_string());
+        self
+    }
+    
+    /// サイズを設定
+    pub fn with_size(mut self, width: u32, height: u32) -> Self {
+        self.config.width = Some(width);
+        self.config.height = Some(height);
+        self
+    }
+    
+    /// マージンを設定
+    pub fn with_margin(mut self, top: u32, right: u32, bottom: u32, left: u32) -> Self {
+        self.config.margin = Some(ChartMargin {
+            top,
+            right,
+            bottom,
+            left,
+        });
+        self
+    }
+    
+    /// メタデータを設定
+    pub fn with_metadata(mut self, metadata: HashMap<String, String>) -> Self {
+        self.config.metadata = Some(metadata);
+        self
+    }
+    
+    /// OHLCデータシリーズを追加
+    pub fn add_series(mut self, series: OHLCDataSeries) -> Self {
+        self.series.push(series);
+        self
+    }
+    
+    /// OHLCチャートを構築
+    pub fn build(self) -> OHLCChart {
+        let now = Utc::now();
+        
+        OHLCChart {
+            config: self.config,
+            series: self.series,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+}
+
+/// データシリーズビルダー
+pub struct DataSeriesBuilder {
+    /// シリーズID
+    id: String,
+    /// シリーズ名
+    name: String,
+    /// データポイント
+    data_points: Vec<DataPoint>,
+    /// 色
+    color: Option<String>,
+    /// 線のスタイル
+    line_style: Option<String>,
+    /// マーカーのスタイル
+    marker_style: Option<String>,
+    /// メタデータ
+    metadata: Option<HashMap<String, String>>,
+}
+
+impl DataSeriesBuilder {
+    /// 新しいデータシリーズビルダーを作成
+    pub fn new(id: &str, name: &str) -> Self {
+        Self {
+            id: id.to_string(),
+            name: name.to_string(),
+            data_points: Vec::new(),
+            color: None,
+            line_style: None,
+            marker_style: None,
+            metadata: None,
+        }
+    }
+    
+    /// 色を設定
+    pub fn with_color(mut self, color: &str) -> Self {
+        self.color = Some(color.to_string());
+        self
+    }
+    
+    /// 線のスタイルを設定
+    pub fn with_line_style(mut self, style: &str) -> Self {
+        self.line_style = Some(style.to_string());
+        self
+    }
+    
+    /// マーカーのスタイルを設定
+    pub fn with_marker_style(mut self, style: &str) -> Self {
+        self.marker_style = Some(style.to_string());
+        self
+    }
+    
+    /// メタデータを設定
+    pub fn with_metadata(mut self, metadata: HashMap<String, String>) -> Self {
+        self.metadata = Some(metadata);
+        self
+    }
+    
+    /// データポイントを追加
+    pub fn add_data_point(mut self, timestamp: DateTime<Utc>, value: f64) -> Self {
+        self.data_points.push(DataPoint {
+            timestamp,
+            value,
+            metadata: None,
+        });
+        self
+    }
+    
+    /// メタデータ付きデータポイントを追加
+    pub fn add_data_point_with_metadata(mut self, timestamp: DateTime<Utc>, value: f64, metadata: HashMap<String, String>) -> Self {
+        self.data_points.push(DataPoint {
+            timestamp,
+            value,
+            metadata: Some(metadata),
+        });
+        self
+    }
+    
+    /// 複数のデータポイントを追加
+    pub fn add_data_points(mut self, points: Vec<(DateTime<Utc>, f64)>) -> Self {
+        for (timestamp, value) in points {
+            self.data_points.push(DataPoint {
+                timestamp,
+                value,
+                metadata: None,
+            });
+        }
+        self
+    }
+    
+    /// データシリーズを構築
+    pub fn build(self) -> DataSeries {
+        DataSeries {
+            id: self.id,
+            name: self.name,
+            data_points: self.data_points,
+            color: self.color,
+            line_style: self.line_style,
+            marker_style: self.marker_style,
+            metadata: self.metadata,
+        }
+    }
+}
+
+/// OHLCデータシリーズビルダー
+pub struct OHLCDataSeriesBuilder {
+    /// シリーズID
+    id: String,
+    /// シリーズ名
+    name: String,
+    /// OHLCデータポイント
+    data_points: Vec<OHLCDataPoint>,
+    /// 上昇色
+    up_color: Option<String>,
+    /// 下降色
+    down_color: Option<String>,
+    /// メタデータ
+    metadata: Option<HashMap<String, String>>,
+}
+
+impl OHLCDataSeriesBuilder {
+    /// 新しいOHLCデータシリーズビルダーを作成
+    pub fn new(id: &str, name: &str) -> Self {
+        Self {
+            id: id.to_string(),
+            name: name.to_string(),
+            data_points: Vec::new(),
+            up_color: None,
+            down_color: None,
+            metadata: None,
+        }
+    }
+    
+    /// 上昇色を設定
+    pub fn with_up_color(mut self, color: &str) -> Self {
+        self.up_color = Some(color.to_string());
+        self
+    }
+    
+    /// 下降色を設定
+    pub fn with_down_color(mut self, color: &str) -> Self {
+        self.down_color = Some(color.to_string());
+        self
+    }
+    
+    /// メタデータを設定
+    pub fn with_metadata(mut self, metadata: HashMap<String, String>) -> Self {
+        self.metadata = Some(metadata);
+        self
+    }
+    
+    /// OHLCデータポイントを追加
+    pub fn add_data_point(mut self, timestamp: DateTime<Utc>, open: f64, high: f64, low: f64, close: f64) -> Self {
+        self.data_points.push(OHLCDataPoint {
+            timestamp,
+            open,
+            high,
+            low,
+            close,
+            volume: None,
+            metadata: None,
+        });
+        self
+    }
+    
+    /// 出来高付きOHLCデータポイントを追加
+    pub fn add_data_point_with_volume(mut self, timestamp: DateTime<Utc>, open: f64, high: f64, low: f64, close: f64, volume: f64) -> Self {
+        self.data_points.push(OHLCDataPoint {
+            timestamp,
+            open,
+            high,
+            low,
+            close,
+            volume: Some(volume),
+            metadata: None,
+        });
+        self
+    }
+    
+    /// メタデータ付きOHLCデータポイントを追加
+    pub fn add_data_point_with_metadata(mut self, timestamp: DateTime<Utc>, open: f64, high: f64, low: f64, close: f64, volume: Option<f64>, metadata: HashMap<String, String>) -> Self {
+        self.data_points.push(OHLCDataPoint {
+            timestamp,
+            open,
+            high,
+            low,
+            close,
+            volume,
+            metadata: Some(metadata),
+        });
+        self
+    }
+    
+    /// 複数のOHLCデータポイントを追加
+    pub fn add_data_points(mut self, points: Vec<(DateTime<Utc>, f64, f64, f64, f64)>) -> Self {
+        for (timestamp, open, high, low, close) in points {
+            self.data_points.push(OHLCDataPoint {
+                timestamp,
+                open,
+                high,
+                low,
+                close,
+                volume: None,
+                metadata: None,
+            });
+        }
+        self
+    }
+    
+    /// 複数の出来高付きOHLCデータポイントを追加
+    pub fn add_data_points_with_volume(mut self, points: Vec<(DateTime<Utc>, f64, f64, f64, f64, f64)>) -> Self {
+        for (timestamp, open, high, low, close, volume) in points {
+            self.data_points.push(OHLCDataPoint {
+                timestamp,
+                open,
+                high,
+                low,
+                close,
+                volume: Some(volume),
+                metadata: None,
+            });
+        }
+        self
+    }
+    
+    /// OHLCデータシリーズを構築
+    pub fn build(self) -> OHLCDataSeries {
+        OHLCDataSeries {
+            id: self.id,
+            name: self.name,
+            data_points: self.data_points,
+            up_color: self.up_color,
+            down_color: self.down_color,
+            metadata: self.metadata,
+        }
+    }
+}
+
+/// チャートデータアグリゲーター
+pub struct ChartDataAggregator;
+
+impl ChartDataAggregator {
+    /// 時間枠でデータを集約
+    pub fn aggregate_by_timeframe(data_points: &[DataPoint], time_frame: &TimeFrame) -> Vec<DataPoint> {
+        if data_points.is_empty() {
+            return Vec::new();
+        }
+        
+        // データポイントを時間順にソート
+        let mut sorted_points = data_points.to_vec();
+        sorted_points.sort_by(|a, b| a.timestamp.cmp(&b.timestamp));
+        
+        // 最初と最後のタイムスタンプを取得
+        let start_time = sorted_points.first().unwrap().timestamp;
+        let end_time = sorted_points.last().unwrap().timestamp;
+        
+        // 時間枠の秒数を取得
+        let frame_seconds = time_frame.to_seconds();
+        
+        // 結果を格納するベクター
+        let mut result = Vec::new();
+        
+        // 現在の時間枠の開始時刻
+        let mut current_frame_start = start_time;
+        
+        while current_frame_start <= end_time {
+            // 現在の時間枠の終了時刻
+            let current_frame_end = current_frame_start + Duration::seconds(frame_seconds);
+            
+            // 現在の時間枠に含まれるデータポイントを抽出
+            let frame_points: Vec<&DataPoint> = sorted_points.iter()
+                .filter(|p| p.timestamp >= current_frame_start && p.timestamp < current_frame_end)
+                .collect();
+            
+            if !frame_points.is_empty() {
+                // 値の平均を計算
+                let avg_value = frame_points.iter().map(|p| p.value).sum::<f64>() / frame_points.len() as f64;
+                
+                // 集約されたデータポイントを作成
+                let aggregated_point = DataPoint {
+                    timestamp: current_frame_start,
+                    value: avg_value,
+                    metadata: None,
+                };
+                
+                result.push(aggregated_point);
+            }
+            
+            // 次の時間枠に移動
+            current_frame_start = current_frame_end;
+        }
+        
+        result
+    }
+    
+    /// 時間枠でOHLCデータを集約
+    pub fn aggregate_ohlc_by_timeframe(data_points: &[OHLCDataPoint], time_frame: &TimeFrame) -> Vec<OHLCDataPoint> {
+        if data_points.is_empty() {
+            return Vec::new();
+        }
+        
+        // データポイントを時間順にソート
+        let mut sorted_points = data_points.to_vec();
+        sorted_points.sort_by(|a, b| a.timestamp.cmp(&b.timestamp));
+        
+        // 最初と最後のタイムスタンプを取得
+        let start_time = sorted_points.first().unwrap().timestamp;
+        let end_time = sorted_points.last().unwrap().timestamp;
+        
+        // 時間枠の秒数を取得
+        let frame_seconds = time_frame.to_seconds();
+        
+        // 結果を格納するベクター
+        let mut result = Vec::new();
+        
+        // 現在の時間枠の開始時刻
+        let mut current_frame_start = start_time;
+        
+        while current_frame_start <= end_time {
+            // 現在の時間枠の終了時刻
+            let current_frame_end = current_frame_start + Duration::seconds(frame_seconds);
+            
+            // 現在の時間枠に含まれるデータポイントを抽出
+            let frame_points: Vec<&OHLCDataPoint> = sorted_points.iter()
+                .filter(|p| p.timestamp >= current_frame_start && p.timestamp < current_frame_end)
+                .collect();
+            
+            if !frame_points.is_empty() {
+                // 始値は期間内の最初のポイントの始値
+                let open = frame_points.first().unwrap().open;
+                
+                // 高値は期間内の最大値
+                let high = frame_points.iter().map(|p| p.high).fold(f64::NEG_INFINITY, f64::max);
+                
+                // 安値は期間内の最小値
+                let low = frame_points.iter().map(|p| p.low).fold(f64::INFINITY, f64::min);
+                
+                // 終値は期間内の最後のポイントの終値
+                let close = frame_points.last().unwrap().close;
+                
+                // 出来高は期間内の合計
+                let volume = if frame_points.iter().all(|p| p.volume.is_some()) {
+                    Some(frame_points.iter().filter_map(|p| p.volume).sum())
+                } else {
+                    None
+                };
+                
+                // 集約されたOHLCデータポイントを作成
+                let aggregated_point = OHLCDataPoint {
+                    timestamp: current_frame_start,
+                    open,
+                    high,
+                    low,
+                    close,
+                    volume,
+                    metadata: None,
+                };
+                
+                result.push(aggregated_point);
+            }
+            
+            // 次の時間枠に移動
+            current_frame_start = current_frame_end;
+        }
+        
+        result
+    }
+    
+    /// 移動平均を計算
+    pub fn calculate_moving_average(data_points: &[DataPoint], period: usize) -> Vec<DataPoint> {
+        if data_points.len() < period {
+            return Vec::new();
+        }
+        
+        // データポイントを時間順にソート
+        let mut sorted_points = data_points.to_vec();
+        sorted_points.sort_by(|a, b| a.timestamp.cmp(&b.timestamp));
+        
+        // 結果を格納するベクター
+        let mut result = Vec::new();
+        
+        // 移動平均を計算
+        for i in period-1..sorted_points.len() {
+            let sum: f64 = sorted_points[i-(period-1)..=i].iter().map(|p| p.value).sum();
+            let avg = sum / period as f64;
+            
+            let ma_point = DataPoint {
+                timestamp: sorted_points[i].timestamp,
+                value: avg,
+                metadata: None,
+            };
+            
+            result.push(ma_point);
+        }
+        
+        result
+    }
+    
+    /// 指数移動平均を計算
+    pub fn calculate_exponential_moving_average(data_points: &[DataPoint], period: usize) -> Vec<DataPoint> {
+        if data_points.len() < period {
+            return Vec::new();
+        }
+        
+        // データポイントを時間順にソート
+        let mut sorted_points = data_points.to_vec();
+        sorted_points.sort_by(|a, b| a.timestamp.cmp(&b.timestamp));
+        
+        // 結果を格納するベクター
+        let mut result = Vec::new();
+        
+        // 最初のSMAを計算
+        let initial_sum: f64 = sorted_points[0..period].iter().map(|p| p.value).sum();
+        let initial_sma = initial_sum / period as f64;
+        
+        // 平滑化係数
+        let alpha = 2.0 / (period as f64 + 1.0);
+        
+        // 最初のEMAはSMAと同じ
+        let mut current_ema = initial_sma;
+        
+        // 最初のEMAを追加
+        result.push(DataPoint {
+            timestamp: sorted_points[period-1].timestamp,
+            value: current_ema,
+            metadata: None,
+        });
+        
+        // 残りのEMAを計算
+        for i in period..sorted_points.len() {
+            current_ema = alpha * sorted_points[i].value + (1.0 - alpha) * current_ema;
+            
+            result.push(DataPoint {
+                timestamp: sorted_points[i].timestamp,
+                value: current_ema,
+                metadata: None,
+            });
+        }
+        
+        result
+    }
+    
+    /// ボリンジャーバンドを計算
+    pub fn calculate_bollinger_bands(data_points: &[DataPoint], period: usize, std_dev_multiplier: f64) -> (Vec<DataPoint>, Vec<DataPoint>, Vec<DataPoint>) {
+        if data_points.len() < period {
+            return (Vec::new(), Vec::new(), Vec::new());
+        }
+        
+        // データポイントを時間順にソート
+        let mut sorted_points = data_points.to_vec();
+        sorted_points.sort_by(|a, b| a.timestamp.cmp(&b.timestamp));
+        
+        // 移動平均を計算
+        let middle_band = Self::calculate_moving_average(&sorted_points, period);
+        
+        // 上下のバンドを計算
+        let mut upper_band = Vec::new();
+        let mut lower_band = Vec::new();
+        
+        for (i, ma_point) in middle_band.iter().enumerate() {
+            let start_idx = i;
+            let end_idx = i + period;
+            
+            if end_idx <= sorted_points.len() {
+                // 標準偏差を計算
+                let mean = ma_point.value;
+                let variance: f64 = sorted_points[start_idx..end_idx].iter()
+                    .map(|p| (p.value - mean).powi(2))
+                    .sum::<f64>() / period as f64;
+                let std_dev = variance.sqrt();
+                
+                // 上下のバンドを計算
+                let upper = mean + std_dev_multiplier * std_dev;
+                let lower = mean - std_dev_multiplier * std_dev;
+                
+                upper_band.push(DataPoint {
+                    timestamp: ma_point.timestamp,
+                    value: upper,
+                    metadata: None,
+                });
+                
+                lower_band.push(DataPoint {
+                    timestamp: ma_point.timestamp,
+                    value: lower,
+                    metadata: None,
+                });
+            }
+        }
+        
+        (middle_band, upper_band, lower_band)
+    }
+    
+    /// 相対力指数（RSI）を計算
+    pub fn calculate_rsi(data_points: &[DataPoint], period: usize) -> Vec<DataPoint> {
+        if data_points.len() <= period {
+            return Vec::new();
+        }
+        
+        // データポイントを時間順にソート
+        let mut sorted_points = data_points.to_vec();
+        sorted_points.sort_by(|a, b| a.timestamp.cmp(&b.timestamp));
+        
+        // 結果を格納するベクター
+        let mut result = Vec::new();
+        
+        // 価格変動を計算
+        let mut price_changes = Vec::new();
+        for i in 1..sorted_points.len() {
+            price_changes.push(sorted_points[i].value - sorted_points[i-1].value);
+        }
+        
+        // 最初のRSIを計算
+        let mut gains = 0.0;
+        let mut losses = 0.0;
+        
+        for i in 0..period {
+            if price_changes[i] >= 0.0 {
+                gains += price_changes[i];
+            } else {
+                losses -= price_changes[i];
+            }
+        }
+        
+        let avg_gain = gains / period as f64;
+        let avg_loss = losses / period as f64;
+        
+        let mut rs = if avg_loss == 0.0 { 100.0 } else { avg_gain / avg_loss };
+        let mut rsi = 100.0 - (100.0 / (1.0 + rs));
+        
+        result.push(DataPoint {
+            timestamp: sorted_points[period].timestamp,
+            value: rsi,
+            metadata: None,
+        });
+        
+        // 残りのRSIを計算
+        let mut current_avg_gain = avg_gain;
+        let mut current_avg_loss = avg_loss;
+        
+        for i in period..price_changes.len() {
+            // 平均利益と平均損失を更新
+            if price_changes[i] >= 0.0 {
+                current_avg_gain = (current_avg_gain * (period as f64 - 1.0) + price_changes[i]) / period as f64;
+                current_avg_loss = (current_avg_loss * (period as f64 - 1.0)) / period as f64;
+            } else {
+                current_avg_gain = (current_avg_gain * (period as f64 - 1.0)) / period as f64;
+                current_avg_loss = (current_avg_loss * (period as f64 - 1.0) - price_changes[i]) / period as f64;
+            }
+            
+            // RSIを計算
+            rs = if current_avg_loss == 0.0 { 100.0 } else { current_avg_gain / current_avg_loss };
+            rsi = 100.0 - (100.0 / (1.0 + rs));
+            
+            result.push(DataPoint {
+                timestamp: sorted_points[i+1].timestamp,
+                value: rsi,
+                metadata: None,
+            });
+        }
+        
+        result
+    }
+    
+    /// 移動平均収束拡散（MACD）を計算
+    pub fn calculate_macd(data_points: &[DataPoint], fast_period: usize, slow_period: usize, signal_period: usize) -> (Vec<DataPoint>, Vec<DataPoint>, Vec<DataPoint>) {
+        if data_points.len() < slow_period + signal_period {
+            return (Vec::new(), Vec::new(), Vec::new());
+        }
+        
+        // データポイントを時間順にソート
+        let mut sorted_points = data_points.to_vec();
+        sorted_points.sort_by(|a, b| a.timestamp.cmp(&b.timestamp));
+        
+        // 短期EMAを計算
+        let fast_ema = Self::calculate_exponential_moving_average(&sorted_points, fast_period);
+        
+        // 長期EMAを計算
+        let slow_ema = Self::calculate_exponential_moving_average(&sorted_points, slow_period);
+        
+        // MACDラインを計算
+        let mut macd_line = Vec::new();
+        
+        // 長期EMAが短期EMAより少ない場合、短期EMAを長期EMAの長さに合わせる
+        let start_idx = slow_ema.len() - fast_ema.len();
+        
+        for i in 0..slow_ema.len() - start_idx {
+            let macd_value = fast_ema[i].value - slow_ema[i + start_idx].value;
+            
+            macd_line.push(DataPoint {
+                timestamp: slow_ema[i + start_idx].timestamp,
+                value: macd_value,
+                metadata: None,
+            });
+        }
+        
+        // シグナルラインを計算
+        let signal_line = Self::calculate_exponential_moving_average(&macd_line, signal_period);
+        
+        // ヒストグラムを計算
+        let mut histogram = Vec::new();
+        
+        for i in 0..signal_line.len() {
+            let hist_value = macd_line[i + macd_line.len() - signal_line.len()].value - signal_line[i].value;
+            
+            histogram.push(DataPoint {
+                timestamp: signal_line[i].timestamp,
+                value: hist_value,
+                metadata: None,
+            });
+        }
+        
+        (macd_line, signal_line, histogram)
+    }
+}
+
+/// チャートレンダラー
+pub trait ChartRenderer {
+    /// チャートをレンダリング
+    fn render_chart(&self, chart: &Chart) -> Result<String, Error>;
+    
+    /// OHLCチャートをレンダリング
+    fn render_ohlc_chart(&self, chart: &OHLCChart) -> Result<String, Error>;
+}
+
+/// SVGチャートレンダラー
+pub struct SVGChartRenderer;
+
+impl ChartRenderer for SVGChartRenderer {
+    fn render_chart(&self, chart: &Chart) -> Result<String, Error> {
+        // 実際の実装では、SVG形式でチャートをレンダリングする
+        // ここでは簡易的な実装として、SVGのテンプレートを返す
+        
+        let width = chart.config.width.unwrap_or(800);
+        let height = chart.config.height.unwrap_or(600);
+        
+        let svg = format!(
+            r#"<svg width="{}" height="{}" xmlns="http://www.w3.org/2000/svg">
+                <title>{}</title>
+                <rect width="100%" height="100%" fill="white"/>
+                <text x="50%" y="30" font-family="Arial" font-size="20" text-anchor="middle">{}</text>
+                <!-- ここに実際のチャートデータが描画される -->
+            </svg>"#,
+            width, height, chart.config.title, chart.config.title
+        );
+        
+        Ok(svg)
+    }
+    
+    fn render_ohlc_chart(&self, chart: &OHLCChart) -> Result<String, Error> {
+        // 実際の実装では、SVG形式でOHLCチャートをレンダリングする
+        // ここでは簡易的な実装として、SVGのテンプレートを返す
+        
+        let width = chart.config.width.unwrap_or(800);
+        let height = chart.config.height.unwrap_or(600);
+        
+        let svg = format!(
+            r#"<svg width="{}" height="{}" xmlns="http://www.w3.org/2000/svg">
+                <title>{}</title>
+                <rect width="100%" height="100%" fill="white"/>
+                <text x="50%" y="30" font-family="Arial" font-size="20" text-anchor="middle">{}</text>
+                <!-- ここに実際のOHLCチャートデータが描画される -->
+            </svg>"#,
+            width, height, chart.config.title, chart.config.title
+        );
+        
+        Ok(svg)
+    }
+}
+
+/// HTMLチャートレンダラー
+pub struct HTMLChartRenderer;
+
+impl ChartRenderer for HTMLChartRenderer {
+    fn render_chart(&self, chart: &Chart) -> Result<String, Error> {
+        // 実際の実装では、HTML/JavaScript（例：Chart.js）を使用してチャートをレンダリングする
+        // ここでは簡易的な実装として、HTMLのテンプレートを返す
+        
+        let width = chart.config.width.unwrap_or(800);
+        let height = chart.config.height.unwrap_or(600);
+        
+        let html = format!(
+            r#"<!DOCTYPE html>
+            <html>
+            <head>
+                <title>{}</title>
+                <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+            </head>
+            <body>
+                <div style="width:{}px;height:{}px;">
+                    <canvas id="myChart"></canvas>
+                </div>
+                <script>
+                    // ここに実際のChart.jsコードが入る
+                    const ctx = document.getElementById('myChart');
+                    new Chart(ctx, {{
+                        type: '{}',
+                        data: {{
+                            // データ
+                        }},
+                        options: {{
+                            // オプション
+                        }}
+                    }});
+                </script>
+            </body>
+            </html>"#,
+            chart.config.title, width, height, chart.config.chart_type.to_string().to_lowercase()
+        );
+        
+        Ok(html)
+    }
+    
+    fn render_ohlc_chart(&self, chart: &OHLCChart) -> Result<String, Error> {
+        // 実際の実装では、HTML/JavaScript（例：TradingView Lightweight Charts）を使用してOHLCチャートをレンダリングする
+        // ここでは簡易的な実装として、HTMLのテンプレートを返す
+        
+        let width = chart.config.width.unwrap_or(800);
+        let height = chart.config.height.unwrap_or(600);
+        
+        let html = format!(
+            r#"<!DOCTYPE html>
+            <html>
+            <head>
+                <title>{}</title>
+                <script src="https://unpkg.com/lightweight-charts/dist/lightweight-charts.standalone.production.js"></script>
+            </head>
+            <body>
+                <div id="chart" style="width:{}px;height:{}px;"></div>
+                <script>
+                    // ここに実際のLightweight Chartsコードが入る
+                    const chart = LightweightCharts.createChart(document.getElementById('chart'), {{
+                        width: {},
+                        height: {}
+                    }});
+                    
+                    const candlestickSeries = chart.addCandlestickSeries();
+                    // データ
+                </script>
+            </body>
+            </html>"#,
+            chart.config.title, width, height, width, height
+        );
+        
+        Ok(html)
+    }
+}
+
+/// チャートエクスポーター
+pub trait ChartExporter {
+    /// チャートをエクスポート
+    fn export_chart(&self, chart: &Chart, format: &str) -> Result<Vec<u8>, Error>;
+    
+    /// OHLCチャートをエクスポート
+    fn export_ohlc_chart(&self, chart: &OHLCChart, format: &str) -> Result<Vec<u8>, Error>;
+}
+
+/// 基本チャートエクスポーター
+pub struct BasicChartExporter {
+    /// レンダラー
+    renderer: Box<dyn ChartRenderer>,
+}
+
+impl BasicChartExporter {
+    /// 新しい基本チャートエクスポーターを作成
+    pub fn new(renderer: Box<dyn ChartRenderer>) -> Self {
+        Self { renderer }
+    }
+}
+
+impl ChartExporter for BasicChartExporter {
+    fn export_chart(&self, chart: &Chart, format: &str) -> Result<Vec<u8>, Error> {
+        match format.to_lowercase().as_str() {
+            "svg" => {
+                let svg = self.renderer.render_chart(chart)?;
+                Ok(svg.into_bytes())
+            },
+            "html" => {
+                let html = self.renderer.render_chart(chart)?;
+                Ok(html.into_bytes())
+            },
+            _ => Err(Error::InvalidInput(format!("未対応のエクスポート形式: {}", format))),
+        }
+    }
+    
+    fn export_ohlc_chart(&self, chart: &OHLCChart, format: &str) -> Result<Vec<u8>, Error> {
+        match format.to_lowercase().as_str() {
+            "svg" => {
+                let svg = self.renderer.render_ohlc_chart(chart)?;
+                Ok(svg.into_bytes())
+            },
+            "html" => {
+                let html = self.renderer.render_ohlc_chart(chart)?;
+                Ok(html.into_bytes())
+            },
+            _ => Err(Error::InvalidInput(format!("未対応のエクスポート形式: {}", format))),
+        }
+    }
+}
+
+/// チャートマネージャー
+pub struct ChartManager {
+    /// チャート
+    charts: HashMap<String, Chart>,
+    /// OHLCチャート
+    ohlc_charts: HashMap<String, OHLCChart>,
+    /// レンダラー
+    renderer: Box<dyn ChartRenderer>,
+    /// エクスポーター
+    exporter: Box<dyn ChartExporter>,
+}
+
+impl ChartManager {
+    /// 新しいチャートマネージャーを作成
+    pub fn new() -> Self {
+        let renderer = Box::new(SVGChartRenderer);
+        let exporter = Box::new(BasicChartExporter::new(Box::new(SVGChartRenderer)));
+        
+        Self {
+            charts: HashMap::new(),
+            ohlc_charts: HashMap::new(),
+            renderer,
+            exporter,
+        }
+    }
+    
+    /// チャートを作成
+    pub fn create_chart(&mut self, chart: Chart) -> Result<(), Error> {
+        if self.charts.contains_key(&chart.config.id) {
+            return Err(Error::AlreadyExists(format!("チャート {} は既に存在します", chart.config.id)));
+        }
+        
+        self.charts.insert(chart.config.id.clone(), chart);
+        
+        Ok(())
+    }
+    
+    /// OHLCチャートを作成
+    pub fn create_ohlc_chart(&mut self, chart: OHLCChart) -> Result<(), Error> {
+        if self.ohlc_charts.contains_key(&chart.config.id) {
+            return Err(Error::AlreadyExists(format!("OHLCチャート {} は既に存在します", chart.config.id)));
+        }
+        
+        self.ohlc_charts.insert(chart.config.id.clone(), chart);
+        
+        Ok(())
+    }
+    
+    /// チャートを取得
+    pub fn get_chart(&self, id: &str) -> Result<&Chart, Error> {
+        self.charts.get(id)
+            .ok_or_else(|| Error::NotFound(format!("チャート {} が見つかりません", id)))
+    }
+    
+    /// OHLCチャートを取得
+    pub fn get_ohlc_chart(&self, id: &str) -> Result<&OHLCChart, Error> {
+        self.ohlc_charts.get(id)
+            .ok_or_else(|| Error::NotFound(format!("OHLCチャート {} が見つかりません", id)))
+    }
+    
+    /// チャートを削除
+    pub fn delete_chart(&mut self, id: &str) -> Result<(), Error> {
+        if self.charts.remove(id).is_none() {
+            return Err(Error::NotFound(format!("チャート {} が見つかりません", id)));
+        }
+        
+        Ok(())
+    }
+    
+    /// OHLCチャートを削除
+    pub fn delete_ohlc_chart(&mut self, id: &str) -> Result<(), Error> {
+        if self.ohlc_charts.remove(id).is_none() {
+            return Err(Error::NotFound(format!("OHLCチャート {} が見つかりません", id)));
+        }
+        
+        Ok(())
+    }
+    
+    /// チャートをレンダリング
+    pub fn render_chart(&self, id: &str) -> Result<String, Error> {
+        let chart = self.get_chart(id)?;
+        self.renderer.render_chart(chart)
+    }
+    
+    /// OHLCチャートをレンダリング
+    pub fn render_ohlc_chart(&self, id: &str) -> Result<String, Error> {
+        let chart = self.get_ohlc_chart(id)?;
+        self.renderer.render_ohlc_chart(chart)
+    }
+    
+    /// チャートをエクスポート
+    pub fn export_chart(&self, id: &str, format: &str) -> Result<Vec<u8>, Error> {
+        let chart = self.get_chart(id)?;
+        self.exporter.export_chart(chart, format)
+    }
+    
+    /// OHLCチャートをエクスポート
+    pub fn export_ohlc_chart(&self, id: &str, format: &str) -> Result<Vec<u8>, Error> {
+        let chart = self.get_ohlc_chart(id)?;
+        self.exporter.export_ohlc_chart(chart, format)
+    }
+    
+    /// 全チャートを取得
+    pub fn get_all_charts(&self) -> Vec<&Chart> {
+        self.charts.values().collect()
+    }
+    
+    /// 全OHLCチャートを取得
+    pub fn get_all_ohlc_charts(&self) -> Vec<&OHLCChart> {
+        self.ohlc_charts.values().collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    
+    #[test]
+    fn test_chart_builder() {
+        let chart = ChartBuilder::new("chart1", ChartType::Line, "テストチャート")
+            .with_subtitle("サブタイトル")
+            .with_x_axis_label("X軸")
+            .with_y_axis_label("Y軸")
+            .with_size(800, 600)
+            .build();
+        
+        assert_eq!(chart.config.id, "chart1");
+        assert_eq!(chart.config.chart_type, ChartType::Line);
+        assert_eq!(chart.config.title, "テストチャート");
+        assert_eq!(chart.config.subtitle, Some("サブタイトル".to_string()));
+        assert_eq!(chart.config.x_axis_label, Some("X軸".to_string()));
+        assert_eq!(chart.config.y_axis_label, Some("Y軸".to_string()));
+        assert_eq!(chart.config.width, Some(800));
+        assert_eq!(chart.config.height, Some(600));
+    }
+    
+    #[test]
+    fn test_ohlc_chart_builder() {
+        let chart = OHLCChartBuilder::new("chart2", "OHLCテストチャート")
+            .with_subtitle("サブタイトル")
+            .with_x_axis_label("日付")
+            .with_y_axis_label("価格")
+            .with_size(800, 600)
+            .build();
+        
+        assert_eq!(chart.config.id, "chart2");
+        assert_eq!(chart.config.chart_type, ChartType::Candlestick);
+        assert_eq!(chart.config.title, "OHLCテストチャート");
+        assert_eq!(chart.config.subtitle, Some("サブタイトル".to_string()));
+        assert_eq!(chart.config.x_axis_label, Some("日付".to_string()));
+        assert_eq!(chart.config.y_axis_label, Some("価格".to_string()));
+        assert_eq!(chart.config.width, Some(800));
+        assert_eq!(chart.config.height, Some(600));
+    }
+    
+    #[test]
+    fn test_data_series_builder() {
+        let now = Utc::now();
+        
+        let series = DataSeriesBuilder::new("series1", "テストシリーズ")
+            .with_color("#FF0000")
+            .with_line_style("solid")
+            .add_data_point(now, 100.0)
+            .add_data_point(now + Duration::hours(1), 110.0)
+            .add_data_point(now + Duration::hours(2), 105.0)
+            .build();
+        
+        assert_eq!(series.id, "series1");
+        assert_eq!(series.name, "テストシリーズ");
+        assert_eq!(series.color, Some("#FF0000".to_string()));
+        assert_eq!(series.line_style, Some("solid".to_string()));
+        assert_eq!(series.data_points.len(), 3);
+        assert_eq!(series.data_points[0].value, 100.0);
+        assert_eq!(series.data_points[1].value, 110.0);
+        assert_eq!(series.data_points[2].value, 105.0);
+    }
+    
+    #[test]
+    fn test_ohlc_data_series_builder() {
+        let now = Utc::now();
+        
+        let series = OHLCDataSeriesBuilder::new("series2", "OHLCテストシリーズ")
+            .with_up_color("#00FF00")
+            .with_down_color("#FF0000")
+            .add_data_point(now, 100.0, 110.0, 95.0, 105.0)
+            .add_data_point_with_volume(now + Duration::hours(1), 105.0, 115.0, 100.0, 110.0, 1000.0)
+            .build();
+        
+        assert_eq!(series.id, "series2");
+        assert_eq!(series.name, "OHLCテストシリーズ");
+        assert_eq!(series.up_color, Some("#00FF00".to_string()));
+        assert_eq!(series.down_color, Some("#FF0000".to_string()));
+        assert_eq!(series.data_points.len(), 2);
+        assert_eq!(series.data_points[0].open, 100.0);
+        assert_eq!(series.data_points[0].high, 110.0);
+        assert_eq!(series.data_points[0].low, 95.0);
+        assert_eq!(series.data_points[0].close, 105.0);
+        assert_eq!(series.data_points[0].volume, None);
+        assert_eq!(series.data_points[1].volume, Some(1000.0));
+    }
+    
+    #[test]
+    fn test_chart_data_aggregator() {
+        let now = Utc::now();
+        
+        // テスト用のデータポイントを作成
+        let data_points = vec![
+            DataPoint { timestamp: now, value: 100.0, metadata: None },
+            DataPoint { timestamp: now + Duration::minutes(10), value: 110.0, metadata: None },
+            DataPoint { timestamp: now + Duration::minutes(20), value: 105.0, metadata: None },
+            DataPoint { timestamp: now + Duration::minutes(30), value: 115.0, metadata: None },
+            DataPoint { timestamp: now + Duration::minutes(40), value: 120.0, metadata: None },
+            DataPoint { timestamp: now + Duration::minutes(50), value: 125.0, metadata: None },
+            DataPoint { timestamp: now + Duration::hours(1), value: 130.0, metadata: None },
+        ];
+        
+        // 30分間隔で集約
+        let aggregated = ChartDataAggregator::aggregate_by_timeframe(&data_points, &TimeFrame::Minute(30));
+        
+        assert_eq!(aggregated.len(), 3);
+        assert_eq!(aggregated[0].value, 105.0); // (100 + 110 + 105) / 3
+        assert_eq!(aggregated[1].value, 117.5); // (115 + 120) / 2
+        assert_eq!(aggregated[2].value, 127.5); // (125 + 130) / 2
+    }
+    
+    #[test]
+    fn test_moving_average() {
+        let now = Utc::now();
+        
+        // テスト用のデータポイントを作成
+        let data_points = vec![
+            DataPoint { timestamp: now, value: 100.0, metadata: None },
+            DataPoint { timestamp: now + Duration::minutes(10), value: 110.0, metadata: None },
+            DataPoint { timestamp: now + Duration::minutes(20), value: 105.0, metadata: None },
+            DataPoint { timestamp: now + Duration::minutes(30), value: 115.0, metadata: None },
+            DataPoint { timestamp: now + Duration::minutes(40), value: 120.0, metadata: None },
+        ];
+        
+        // 3期間の移動平均を計算
+        let ma = ChartDataAggregator::calculate_moving_average(&data_points, 3);
+        
+        assert_eq!(ma.len(), 3);
+        assert_eq!(ma[0].value, 105.0); // (100 + 110 + 105) / 3
+        assert_eq!(ma[1].value, 110.0); // (110 + 105 + 115) / 3
+        assert_eq!(ma[2].value, 113.33333333333333); // (105 + 115 + 120) / 3
+    }
+    
+    #[test]
+    fn test_chart_manager() {
+        let mut manager = ChartManager::new();
+        
+        // チャートを作成
+        let chart = ChartBuilder::new("chart1", ChartType::Line, "テストチャート")
+            .with_subtitle("サブタイトル")
+            .build();
+        
+        manager.create_chart(chart).unwrap();
+        
+        // チャートを取得
+        let retrieved_chart = manager.get_chart("chart1").unwrap();
+        assert_eq!(retrieved_chart.config.title, "テストチャート");
+        
+        // OHLCチャートを作成
+        let ohlc_chart = OHLCChartBuilder::new("chart2", "OHLCテストチャート")
+            .with_subtitle("サブタイトル")
+            .build();
+        
+        manager.create_ohlc_chart(ohlc_chart).unwrap();
+        
+        // OHLCチャートを取得
+        let retrieved_ohlc_chart = manager.get_ohlc_chart("chart2").unwrap();
+        assert_eq!(retrieved_ohlc_chart.config.title, "OHLCテストチャート");
+        
+        // 全チャートを取得
+        let all_charts = manager.get_all_charts();
+        assert_eq!(all_charts.len(), 1);
+        
+        // 全OHLCチャートを取得
+        let all_ohlc_charts = manager.get_all_ohlc_charts();
+        assert_eq!(all_ohlc_charts.len(), 1);
+        
+        // チャートを削除
+        manager.delete_chart("chart1").unwrap();
+        
+        // OHLCチャートを削除
+        manager.delete_ohlc_chart("chart2").unwrap();
+        
+        // 削除後の確認
+        assert!(manager.get_chart("chart1").is_err());
+        assert!(manager.get_ohlc_chart("chart2").is_err());
+    }
+}

--- a/src/chart/mod.rs
+++ b/src/chart/mod.rs
@@ -1,0 +1,8 @@
+pub mod advanced_chart;
+
+pub use advanced_chart::{
+    ChartType, TimeFrame, DataPoint, OHLCDataPoint, DataSeries, OHLCDataSeries,
+    ChartConfig, ChartMargin, Chart, OHLCChart, ChartBuilder, OHLCChartBuilder,
+    DataSeriesBuilder, OHLCDataSeriesBuilder, ChartDataAggregator, ChartRenderer,
+    SVGChartRenderer, HTMLChartRenderer, ChartExporter, BasicChartExporter, ChartManager
+};

--- a/src/cross_chain/enhanced_ethereum_bridge.rs
+++ b/src/cross_chain/enhanced_ethereum_bridge.rs
@@ -1,0 +1,690 @@
+use std::sync::{Arc, RwLock};
+use std::collections::HashMap;
+use std::str::FromStr;
+use tokio::sync::mpsc;
+use tokio::time::{Duration, interval};
+use log::{debug, info, warn, error};
+use serde::{Serialize, Deserialize};
+use web3::{
+    Web3,
+    transports::Http,
+    types::{Address, H256, U256, TransactionRequest, BlockNumber},
+};
+use ethers::{
+    prelude::*,
+    providers::{Provider, Http as EthersHttp},
+    signers::{LocalWallet, Signer},
+};
+
+use crate::error::Error;
+use crate::transaction::Transaction;
+use super::bridge::{CrossChainBridge, BridgeConfig, ChainType, BridgeStatus};
+use super::messaging::{CrossChainMessage, MessageType, MessageStatus};
+use super::transaction::{CrossChainTransaction, TransactionStatus, TransactionProof};
+use super::ethereum_bridge_contract::EthereumBridgeContract;
+use super::token_registry::{TokenRegistry, TokenInfo};
+
+/// 拡張イーサリアムブリッジ
+pub struct EnhancedEthereumBridge {
+    /// 基本ブリッジ
+    base_bridge: CrossChainBridge,
+    /// Web3クライアント
+    web3: Option<Web3<Http>>,
+    /// Ethersプロバイダー
+    provider: Option<Provider<EthersHttp>>,
+    /// ウォレット
+    wallet: Option<LocalWallet>,
+    /// ブリッジコントラクト
+    bridge_contract: Option<EthereumBridgeContract>,
+    /// トークンレジストリ
+    token_registry: Arc<TokenRegistry>,
+    /// ガス価格（Gwei）
+    gas_price: RwLock<U256>,
+    /// 最新のブロック番号
+    latest_block: RwLock<u64>,
+    /// 進行中のクロスチェーントランザクション
+    pending_transactions: RwLock<HashMap<String, CrossChainTransaction>>,
+    /// イベントポーリングタスクが実行中かどうか
+    polling_active: RwLock<bool>,
+}
+
+impl EnhancedEthereumBridge {
+    /// 新しいEnhancedEthereumBridgeを作成
+    pub fn new(
+        config: BridgeConfig,
+        message_sender: mpsc::Sender<CrossChainMessage>,
+        message_receiver: mpsc::Receiver<CrossChainMessage>,
+        token_registry: Arc<TokenRegistry>,
+    ) -> Self {
+        let base_bridge = CrossChainBridge::new(
+            config.clone(),
+            message_sender,
+            message_receiver,
+        );
+        
+        Self {
+            base_bridge,
+            web3: None,
+            provider: None,
+            wallet: None,
+            bridge_contract: None,
+            token_registry,
+            gas_price: RwLock::new(U256::from(5_000_000_000u64)), // 5 Gwei
+            latest_block: RwLock::new(0),
+            pending_transactions: RwLock::new(HashMap::new()),
+            polling_active: RwLock::new(false),
+        }
+    }
+    
+    /// ブリッジを初期化
+    pub async fn initialize(&mut self, private_key: &str) -> Result<(), Error> {
+        info!("Initializing enhanced Ethereum bridge: {} -> {}", 
+            self.base_bridge.get_config().source_chain, 
+            self.base_bridge.get_config().target_chain);
+        
+        // Web3クライアントを初期化
+        let endpoint = self.base_bridge.get_config().target_endpoint.clone();
+        let http = Http::new(&endpoint)
+            .map_err(|e| Error::ConnectionError(format!("Failed to connect to Ethereum node: {}", e)))?;
+        
+        let web3 = Web3::new(http);
+        self.web3 = Some(web3.clone());
+        
+        // Ethersプロバイダーを初期化
+        let provider = Provider::<EthersHttp>::try_from(endpoint.clone())
+            .map_err(|e| Error::ConnectionError(format!("Failed to create Ethers provider: {}", e)))?;
+        
+        self.provider = Some(provider.clone());
+        
+        // ウォレットを初期化
+        let wallet = private_key.parse::<LocalWallet>()
+            .map_err(|e| Error::ValidationError(format!("Invalid private key: {}", e)))?;
+        
+        self.wallet = Some(wallet.clone());
+        
+        // 接続テスト
+        let block_number = web3.eth().block_number().await
+            .map_err(|e| Error::ConnectionError(format!("Failed to get block number: {}", e)))?;
+        
+        let block_number_u64 = block_number.as_u64();
+        *self.latest_block.write().unwrap() = block_number_u64;
+        
+        info!("Connected to Ethereum network. Latest block: {}", block_number_u64);
+        
+        // ガス価格を取得
+        let gas_price = web3.eth().gas_price().await
+            .map_err(|e| Error::ConnectionError(format!("Failed to get gas price: {}", e)))?;
+        
+        *self.gas_price.write().unwrap() = gas_price;
+        
+        info!("Current gas price: {} Gwei", gas_price.as_u64() / 1_000_000_000);
+        
+        // ブリッジコントラクトを初期化
+        let contract_address = match &self.base_bridge.get_config().target_contract {
+            Some(addr) => Address::from_str(addr)
+                .map_err(|e| Error::ValidationError(format!("Invalid contract address: {}", e)))?,
+            None => return Err(Error::ValidationError("Bridge contract address not specified".to_string())),
+        };
+        
+        let mut bridge_contract = EthereumBridgeContract::new(
+            contract_address,
+            web3.clone(),
+            wallet.clone(),
+        );
+        
+        bridge_contract.initialize().await?;
+        self.bridge_contract = Some(bridge_contract);
+        
+        // 基本ブリッジを初期化
+        self.base_bridge.initialize().await?;
+        
+        // トークンレジストリにデフォルトトークンを登録
+        self.token_registry.register_default_tokens()?;
+        
+        // イベントポーリングタスクを開始
+        self.start_event_polling().await?;
+        
+        info!("Enhanced Ethereum bridge initialized successfully");
+        
+        Ok(())
+    }
+    
+    /// イベントポーリングタスクを開始
+    async fn start_event_polling(&self) -> Result<(), Error> {
+        // 既に実行中の場合は何もしない
+        {
+            let polling_active = self.polling_active.read().unwrap();
+            if *polling_active {
+                return Ok(());
+            }
+        }
+        
+        // ポーリングアクティブフラグを設定
+        {
+            let mut polling_active = self.polling_active.write().unwrap();
+            *polling_active = true;
+        }
+        
+        // ブリッジコントラクトを取得
+        let bridge_contract = match &self.bridge_contract {
+            Some(contract) => contract.clone(),
+            None => return Err(Error::ContractError("Bridge contract not initialized".to_string())),
+        };
+        
+        // ポーリング間隔（15秒）
+        let mut interval = interval(Duration::from_secs(15));
+        
+        // ポーリングタスクを開始
+        tokio::spawn(async move {
+            loop {
+                interval.tick().await;
+                
+                // ポーリングが無効化された場合は終了
+                {
+                    let polling_active = self.polling_active.read().unwrap();
+                    if !*polling_active {
+                        break;
+                    }
+                }
+                
+                // イベントをポーリング
+                if let Err(e) = bridge_contract.poll_events().await {
+                    error!("Failed to poll events: {}", e);
+                }
+                
+                // 最新のブロック番号を更新
+                if let Err(e) = self.update_latest_block().await {
+                    error!("Failed to update latest block: {}", e);
+                }
+                
+                // 保留中のトランザクションを処理
+                if let Err(e) = self.process_pending_transactions().await {
+                    error!("Failed to process pending transactions: {}", e);
+                }
+            }
+        });
+        
+        info!("Event polling task started");
+        
+        Ok(())
+    }
+    
+    /// イベントポーリングタスクを停止
+    pub fn stop_event_polling(&self) {
+        let mut polling_active = self.polling_active.write().unwrap();
+        *polling_active = false;
+        info!("Event polling task stopped");
+    }
+    
+    /// 最新のブロック番号を更新
+    async fn update_latest_block(&self) -> Result<u64, Error> {
+        // Web3クライアントを取得
+        let web3 = match &self.web3 {
+            Some(web3) => web3,
+            None => return Err(Error::ConnectionError("Web3 client not initialized".to_string())),
+        };
+        
+        // 最新のブロック番号を取得
+        let block_number = web3.eth().block_number().await
+            .map_err(|e| Error::ConnectionError(format!("Failed to get block number: {}", e)))?;
+        
+        let block_number_u64 = block_number.as_u64();
+        *self.latest_block.write().unwrap() = block_number_u64;
+        
+        Ok(block_number_u64)
+    }
+    
+    /// 保留中のトランザクションを処理
+    async fn process_pending_transactions(&self) -> Result<(), Error> {
+        // 処理するトランザクションのIDリストを取得
+        let tx_ids: Vec<String> = {
+            let pending_transactions = self.pending_transactions.read().unwrap();
+            pending_transactions.keys().cloned().collect()
+        };
+        
+        // 各トランザクションを処理
+        for tx_id in tx_ids {
+            self.check_transaction_status(&tx_id).await?;
+        }
+        
+        Ok(())
+    }
+    
+    /// トランザクションの状態を確認
+    async fn check_transaction_status(&self, tx_id: &str) -> Result<(), Error> {
+        // トランザクションを取得
+        let transaction = {
+            let pending_transactions = self.pending_transactions.read().unwrap();
+            match pending_transactions.get(tx_id) {
+                Some(tx) => tx.clone(),
+                None => return Ok(()),
+            }
+        };
+        
+        // Ethereumトランザクションハッシュを取得
+        let eth_tx_hash = match transaction.get_metadata("eth_tx_hash") {
+            Some(hash) => H256::from_str(hash)
+                .map_err(|e| Error::ValidationError(format!("Invalid transaction hash: {}", e)))?,
+            None => return Ok(()),
+        };
+        
+        // Web3クライアントを取得
+        let web3 = match &self.web3 {
+            Some(web3) => web3,
+            None => return Err(Error::ConnectionError("Web3 client not initialized".to_string())),
+        };
+        
+        // トランザクションのレシートを取得
+        let receipt = web3.eth().transaction_receipt(eth_tx_hash).await
+            .map_err(|e| Error::TransactionError(format!("Failed to get transaction receipt: {}", e)))?;
+        
+        if let Some(receipt) = receipt {
+            // ブロック番号を取得
+            let block_number = receipt.block_number
+                .ok_or_else(|| Error::TransactionError("Missing block number in receipt".to_string()))?
+                .as_u64();
+            
+            // 最新のブロック番号を取得
+            let latest_block = *self.latest_block.read().unwrap();
+            
+            // 確認数を計算
+            let confirmations = latest_block.saturating_sub(block_number) + 1;
+            
+            // 必要な確認数
+            let required_confirmations = self.base_bridge.get_config().confirmation_blocks;
+            
+            let mut updated_transaction = transaction.clone();
+            
+            if receipt.status == Some(U256::from(1)) {
+                // トランザクションが成功
+                if confirmations >= required_confirmations {
+                    // トランザクションが確認された
+                    updated_transaction.status = TransactionStatus::Confirmed;
+                    updated_transaction.set_metadata("confirmations".to_string(), confirmations.to_string());
+                    
+                    // ブロック情報を設定
+                    updated_transaction.set_target_block_info(
+                        receipt.block_hash.unwrap_or_default().to_string(),
+                        block_number,
+                    );
+                    
+                    // トランザクション証明を作成
+                    if let Some(bridge_contract) = &self.bridge_contract {
+                        if let Ok(proof) = self.create_transaction_proof(&updated_transaction, eth_tx_hash).await {
+                            updated_transaction.mark_as_verified(proof);
+                        }
+                    }
+                    
+                    // 保留中のトランザクションから削除
+                    {
+                        let mut pending_transactions = self.pending_transactions.write().unwrap();
+                        pending_transactions.remove(tx_id);
+                    }
+                    
+                    info!("Transaction confirmed: {}", tx_id);
+                } else {
+                    // まだ確認中
+                    updated_transaction.status = TransactionStatus::Confirming;
+                    updated_transaction.set_metadata("confirmations".to_string(), confirmations.to_string());
+                }
+            } else {
+                // トランザクションが失敗
+                updated_transaction.mark_as_failed("Transaction failed on Ethereum".to_string());
+                
+                // 保留中のトランザクションから削除
+                {
+                    let mut pending_transactions = self.pending_transactions.write().unwrap();
+                    pending_transactions.remove(tx_id);
+                }
+                
+                info!("Transaction failed: {}", tx_id);
+            }
+            
+            // トランザクションの状態を更新
+            self.update_transaction(updated_transaction)?;
+        }
+        
+        Ok(())
+    }
+    
+    /// トランザクション証明を作成
+    async fn create_transaction_proof(
+        &self,
+        transaction: &CrossChainTransaction,
+        eth_tx_hash: H256,
+    ) -> Result<TransactionProof, Error> {
+        // Web3クライアントを取得
+        let web3 = match &self.web3 {
+            Some(web3) => web3,
+            None => return Err(Error::ConnectionError("Web3 client not initialized".to_string())),
+        };
+        
+        // トランザクションのレシートを取得
+        let receipt = web3.eth().transaction_receipt(eth_tx_hash).await
+            .map_err(|e| Error::TransactionError(format!("Failed to get transaction receipt: {}", e)))?
+            .ok_or_else(|| Error::TransactionError("Transaction receipt not found".to_string()))?;
+        
+        // ブロック情報を取得
+        let block_number = receipt.block_number
+            .ok_or_else(|| Error::TransactionError("Missing block number in receipt".to_string()))?;
+        
+        let block = web3.eth().block(BlockNumber::Number(block_number)).await
+            .map_err(|e| Error::TransactionError(format!("Failed to get block: {}", e)))?
+            .ok_or_else(|| Error::TransactionError("Block not found".to_string()))?;
+        
+        let block_hash = block.hash
+            .ok_or_else(|| Error::TransactionError("Missing block hash".to_string()))?;
+        
+        // 証明データを作成
+        let proof_data = serde_json::to_vec(&receipt)
+            .map_err(|e| Error::SerializationError(e.to_string()))?;
+        
+        // 署名を作成
+        let wallet = match &self.wallet {
+            Some(wallet) => wallet,
+            None => return Err(Error::ValidationError("Wallet not initialized".to_string())),
+        };
+        
+        let message = format!("{}:{}", eth_tx_hash, block_hash);
+        let signature = wallet.sign_message(message.as_bytes()).to_string();
+        
+        // 証明を作成
+        let proof = TransactionProof::new(
+            transaction.id.clone(),
+            block_hash.to_string(),
+            block_number.as_u64(),
+            block.timestamp.as_u64(),
+            proof_data,
+            signature,
+            wallet.address().to_string(),
+        );
+        
+        Ok(proof)
+    }
+    
+    /// トランザクションの状態を更新
+    fn update_transaction(&self, transaction: CrossChainTransaction) -> Result<(), Error> {
+        // 基本ブリッジのトランザクションマップを更新
+        // 実際の実装では、基本ブリッジのトランザクションマップを直接更新する方法を提供する必要がある
+        
+        Ok(())
+    }
+    
+    /// ShardXからイーサリアムへのトークン転送
+    pub async fn transfer_to_ethereum(
+        &self,
+        token_id: &str,
+        recipient: &str,
+        amount: &str,
+        from_address: &str,
+    ) -> Result<String, Error> {
+        // トークン情報を取得
+        let token = match self.token_registry.get_token(token_id) {
+            Some(token) => token,
+            None => return Err(Error::ValidationError(format!("Token not found: {}", token_id))),
+        };
+        
+        // トークンがイーサリアムチェーンのものであることを確認
+        if token.chain_type != ChainType::Ethereum {
+            return Err(Error::ValidationError(format!("Token is not on Ethereum chain: {}", token_id)));
+        }
+        
+        // 受取人アドレスを検証
+        let recipient_address = Address::from_str(recipient)
+            .map_err(|e| Error::ValidationError(format!("Invalid recipient address: {}", e)))?;
+        
+        // 金額を検証
+        let amount_u256 = U256::from_dec_str(amount)
+            .map_err(|e| Error::ValidationError(format!("Invalid amount: {}", e)))?;
+        
+        // トークンアドレスを取得
+        let token_address = Address::from_str(&token.chain_address)
+            .map_err(|e| Error::ValidationError(format!("Invalid token address: {}", e)))?;
+        
+        // ブリッジコントラクトを取得
+        let bridge_contract = match &self.bridge_contract {
+            Some(contract) => contract,
+            None => return Err(Error::ContractError("Bridge contract not initialized".to_string())),
+        };
+        
+        // トークンがサポートされているか確認
+        if !bridge_contract.is_token_supported(token_address) {
+            return Err(Error::ValidationError(format!("Token not supported by bridge: {}", token.symbol)));
+        }
+        
+        // ShardXトランザクションを作成
+        let tx_id = uuid::Uuid::new_v4().to_string();
+        
+        // 引き出しリクエストを作成
+        let withdrawal_id = bridge_contract.request_withdrawal(
+            token_address,
+            recipient_address,
+            amount_u256,
+            &tx_id,
+        ).await?;
+        
+        // クロスチェーントランザクションを作成
+        let cross_tx = CrossChainTransaction::new(
+            Transaction {
+                id: tx_id.clone(),
+                from: from_address.to_string(),
+                to: recipient.to_string(),
+                amount: amount.to_string(),
+                fee: "0".to_string(),
+                data: Some(format!("Transfer to Ethereum: token={}, recipient={}", token.symbol, recipient)),
+                nonce: 0,
+                timestamp: chrono::Utc::now().timestamp() as u64,
+                signature: "".to_string(),
+                status: crate::transaction::TransactionStatus::Pending,
+                shard_id: "shard-1".to_string(),
+                block_hash: None,
+                block_height: None,
+                parent_id: None,
+            },
+            ChainType::ShardX,
+            ChainType::Ethereum,
+        );
+        
+        // メタデータを設定
+        let mut updated_tx = cross_tx.clone();
+        updated_tx.set_metadata("token_id".to_string(), token_id.to_string());
+        updated_tx.set_metadata("token_symbol".to_string(), token.symbol);
+        updated_tx.set_metadata("withdrawal_id".to_string(), withdrawal_id.to_string());
+        
+        // 保留中のトランザクションに追加
+        {
+            let mut pending_transactions = self.pending_transactions.write().unwrap();
+            pending_transactions.insert(tx_id.clone(), updated_tx.clone());
+        }
+        
+        info!("Created cross-chain transaction from ShardX to Ethereum: {}", tx_id);
+        
+        Ok(tx_id)
+    }
+    
+    /// イーサリアムからShardXへのトークン転送
+    pub async fn transfer_from_ethereum(
+        &self,
+        token_id: &str,
+        shardx_recipient: &str,
+        amount: &str,
+    ) -> Result<String, Error> {
+        // トークン情報を取得
+        let token = match self.token_registry.get_token(token_id) {
+            Some(token) => token,
+            None => return Err(Error::ValidationError(format!("Token not found: {}", token_id))),
+        };
+        
+        // トークンがイーサリアムチェーンのものであることを確認
+        if token.chain_type != ChainType::Ethereum {
+            return Err(Error::ValidationError(format!("Token is not on Ethereum chain: {}", token_id)));
+        }
+        
+        // ShardX受取人アドレスを検証
+        if shardx_recipient.is_empty() {
+            return Err(Error::ValidationError("Invalid ShardX recipient address".to_string()));
+        }
+        
+        // 金額を検証
+        let amount_u256 = U256::from_dec_str(amount)
+            .map_err(|e| Error::ValidationError(format!("Invalid amount: {}", e)))?;
+        
+        // トークンアドレスを取得
+        let token_address = Address::from_str(&token.chain_address)
+            .map_err(|e| Error::ValidationError(format!("Invalid token address: {}", e)))?;
+        
+        // ウォレットを取得
+        let wallet = match &self.wallet {
+            Some(wallet) => wallet,
+            None => return Err(Error::ValidationError("Wallet not initialized".to_string())),
+        };
+        
+        // Web3クライアントを取得
+        let web3 = match &self.web3 {
+            Some(web3) => web3,
+            None => return Err(Error::ConnectionError("Web3 client not initialized".to_string())),
+        };
+        
+        // ブリッジコントラクトアドレスを取得
+        let bridge_address = match &self.base_bridge.get_config().target_contract {
+            Some(addr) => Address::from_str(addr)
+                .map_err(|e| Error::ValidationError(format!("Invalid contract address: {}", e)))?,
+            None => return Err(Error::ValidationError("Bridge contract address not specified".to_string())),
+        };
+        
+        // ERC20コントラクトのABIを取得
+        let erc20_abi = include_bytes!("../../contracts/ethereum/abi/ERC20.json");
+        let erc20_abi = String::from_utf8_lossy(erc20_abi);
+        
+        // ERC20コントラクトインスタンスを作成
+        let erc20_contract = Contract::from_json(
+            web3.eth(),
+            token_address,
+            erc20_abi.as_bytes(),
+        ).map_err(|e| Error::ContractError(format!("Failed to create ERC20 contract instance: {}", e)))?;
+        
+        // approve関数を呼び出し
+        let approve_result = erc20_contract.call(
+            "approve",
+            (bridge_address, amount_u256),
+            wallet.address(),
+            Options::default(),
+        ).await.map_err(|e| Error::ContractError(format!("Failed to approve token transfer: {}", e)))?;
+        
+        // approveトランザクションのレシートを待機
+        let approve_receipt = web3.eth().transaction_receipt(approve_result).await
+            .map_err(|e| Error::TransactionError(format!("Failed to get approve receipt: {}", e)))?
+            .ok_or_else(|| Error::TransactionError("Approve receipt not found".to_string()))?;
+        
+        if approve_receipt.status != Some(U256::from(1)) {
+            return Err(Error::TransactionError("Approve transaction failed".to_string()));
+        }
+        
+        // ブリッジコントラクトのABIを取得
+        let bridge_abi = include_bytes!("../../contracts/ethereum/abi/ShardXBridge.json");
+        let bridge_abi = String::from_utf8_lossy(bridge_abi);
+        
+        // ブリッジコントラクトインスタンスを作成
+        let bridge_contract = Contract::from_json(
+            web3.eth(),
+            bridge_address,
+            bridge_abi.as_bytes(),
+        ).map_err(|e| Error::ContractError(format!("Failed to create bridge contract instance: {}", e)))?;
+        
+        // deposit関数を呼び出し
+        let deposit_result = bridge_contract.call(
+            "deposit",
+            (token_address, amount_u256, shardx_recipient),
+            wallet.address(),
+            Options::default(),
+        ).await.map_err(|e| Error::ContractError(format!("Failed to deposit tokens: {}", e)))?;
+        
+        // トランザクションIDを生成
+        let tx_id = uuid::Uuid::new_v4().to_string();
+        
+        // クロスチェーントランザクションを作成
+        let cross_tx = CrossChainTransaction::new(
+            Transaction {
+                id: tx_id.clone(),
+                from: wallet.address().to_string(),
+                to: shardx_recipient.to_string(),
+                amount: amount.to_string(),
+                fee: "0".to_string(),
+                data: Some(format!("Transfer from Ethereum: token={}", token.symbol)),
+                nonce: 0,
+                timestamp: chrono::Utc::now().timestamp() as u64,
+                signature: "".to_string(),
+                status: crate::transaction::TransactionStatus::Pending,
+                shard_id: "shard-1".to_string(),
+                block_hash: None,
+                block_height: None,
+                parent_id: None,
+            },
+            ChainType::Ethereum,
+            ChainType::ShardX,
+        );
+        
+        // メタデータを設定
+        let mut updated_tx = cross_tx.clone();
+        updated_tx.set_metadata("token_id".to_string(), token_id.to_string());
+        updated_tx.set_metadata("token_symbol".to_string(), token.symbol);
+        updated_tx.set_metadata("eth_tx_hash".to_string(), deposit_result.to_string());
+        
+        // 保留中のトランザクションに追加
+        {
+            let mut pending_transactions = self.pending_transactions.write().unwrap();
+            pending_transactions.insert(tx_id.clone(), updated_tx.clone());
+        }
+        
+        info!("Created cross-chain transaction from Ethereum to ShardX: {}", tx_id);
+        
+        Ok(tx_id)
+    }
+    
+    /// トランザクションの状態を取得
+    pub fn get_transaction_status(&self, tx_id: &str) -> Result<TransactionStatus, Error> {
+        // 保留中のトランザクションから検索
+        {
+            let pending_transactions = self.pending_transactions.read().unwrap();
+            if let Some(tx) = pending_transactions.get(tx_id) {
+                return Ok(tx.status);
+            }
+        }
+        
+        // 基本ブリッジから検索
+        self.base_bridge.get_transaction_status(tx_id)
+    }
+    
+    /// トランザクションの詳細を取得
+    pub fn get_transaction_details(&self, tx_id: &str) -> Result<CrossChainTransaction, Error> {
+        // 保留中のトランザクションから検索
+        {
+            let pending_transactions = self.pending_transactions.read().unwrap();
+            if let Some(tx) = pending_transactions.get(tx_id) {
+                return Ok(tx.clone());
+            }
+        }
+        
+        // 基本ブリッジから検索
+        self.base_bridge.get_transaction_details(tx_id)
+    }
+    
+    /// ブリッジの状態を取得
+    pub fn get_status(&self) -> BridgeStatus {
+        self.base_bridge.get_status()
+    }
+    
+    /// ブリッジの設定を取得
+    pub fn get_config(&self) -> BridgeConfig {
+        self.base_bridge.get_config()
+    }
+    
+    /// ブリッジを停止
+    pub async fn shutdown(&self) -> Result<(), Error> {
+        // イベントポーリングを停止
+        self.stop_event_polling();
+        
+        // 基本ブリッジを停止
+        self.base_bridge.shutdown().await
+    }
+}

--- a/src/cross_chain/ethereum_bridge_contract.rs
+++ b/src/cross_chain/ethereum_bridge_contract.rs
@@ -1,0 +1,432 @@
+use std::sync::{Arc, RwLock};
+use std::collections::HashMap;
+use tokio::sync::mpsc;
+use log::{debug, info, warn, error};
+use serde::{Serialize, Deserialize};
+use web3::{
+    Web3,
+    transports::Http,
+    types::{Address, H256, U256, TransactionRequest, BlockNumber, Log, FilterBuilder},
+    contract::{Contract, Options},
+};
+use ethers::{
+    prelude::*,
+    providers::{Provider, Http as EthersHttp},
+    signers::{LocalWallet, Signer},
+};
+
+use crate::error::Error;
+use crate::transaction::Transaction;
+use crate::wallet::Wallet;
+use super::bridge::{CrossChainBridge, BridgeConfig, ChainType, BridgeStatus};
+use super::messaging::{CrossChainMessage, MessageType, MessageStatus};
+use super::transaction::{CrossChainTransaction, TransactionStatus, TransactionProof};
+
+/// イーサリアムブリッジコントラクト連携
+pub struct EthereumBridgeContract {
+    /// コントラクトアドレス
+    contract_address: Address,
+    /// Web3クライアント
+    web3: Web3<Http>,
+    /// コントラクトインスタンス
+    contract: Option<Contract<Http>>,
+    /// バリデータウォレット
+    validator_wallet: LocalWallet,
+    /// サポートされているトークン
+    supported_tokens: RwLock<HashMap<Address, String>>,
+    /// 処理済みデポジットID
+    processed_deposits: RwLock<HashMap<H256, bool>>,
+    /// 処理済み引き出しID
+    processed_withdrawals: RwLock<HashMap<H256, bool>>,
+    /// 最後に処理したブロック番号
+    last_processed_block: RwLock<u64>,
+}
+
+/// デポジットイベント
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DepositEvent {
+    /// トークンアドレス
+    pub token: Address,
+    /// 送信元アドレス
+    pub from: Address,
+    /// ShardX宛先アドレス
+    pub to_shardx_address: String,
+    /// 金額
+    pub amount: U256,
+    /// デポジットID
+    pub deposit_id: H256,
+}
+
+/// 引き出しイベント
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WithdrawalEvent {
+    /// トークンアドレス
+    pub token: Address,
+    /// 送信先アドレス
+    pub to: Address,
+    /// 金額
+    pub amount: U256,
+    /// 引き出しID
+    pub withdrawal_id: H256,
+}
+
+impl EthereumBridgeContract {
+    /// 新しいEthereumBridgeContractを作成
+    pub fn new(
+        contract_address: Address,
+        web3: Web3<Http>,
+        validator_wallet: LocalWallet,
+    ) -> Self {
+        Self {
+            contract_address,
+            web3: web3.clone(),
+            contract: None,
+            validator_wallet,
+            supported_tokens: RwLock::new(HashMap::new()),
+            processed_deposits: RwLock::new(HashMap::new()),
+            processed_withdrawals: RwLock::new(HashMap::new()),
+            last_processed_block: RwLock::new(0),
+        }
+    }
+
+    /// コントラクトを初期化
+    pub async fn initialize(&mut self) -> Result<(), Error> {
+        // コントラクトABIを読み込み
+        let contract_abi = include_bytes!("../../contracts/ethereum/abi/ShardXBridge.json");
+        let contract_abi = String::from_utf8_lossy(contract_abi);
+        
+        // コントラクトインスタンスを作成
+        let contract = Contract::from_json(
+            self.web3.eth(),
+            self.contract_address,
+            contract_abi.as_bytes(),
+        ).map_err(|e| Error::ContractError(format!("Failed to create contract instance: {}", e)))?;
+        
+        self.contract = Some(contract);
+        
+        // サポートされているトークンを取得
+        self.update_supported_tokens().await?;
+        
+        // 最新のブロック番号を取得
+        let latest_block = self.web3.eth().block_number().await
+            .map_err(|e| Error::ConnectionError(format!("Failed to get latest block number: {}", e)))?;
+        
+        // 最後に処理したブロック番号を更新（最新のブロック番号から1000ブロック前）
+        let start_block = latest_block.as_u64().saturating_sub(1000);
+        *self.last_processed_block.write().unwrap() = start_block;
+        
+        info!("Ethereum bridge contract initialized. Contract address: {}, Starting from block: {}", 
+            self.contract_address, start_block);
+        
+        Ok(())
+    }
+    
+    /// サポートされているトークンを更新
+    async fn update_supported_tokens(&self) -> Result<(), Error> {
+        // 実際の実装では、コントラクトからサポートされているトークンのリストを取得
+        // ここでは簡略化のため、ハードコードしたトークンを使用
+        
+        let mut tokens = self.supported_tokens.write().unwrap();
+        
+        // ETH（ラップドイーサ）
+        let weth_address = Address::from_str("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2")
+            .map_err(|e| Error::ValidationError(format!("Invalid address: {}", e)))?;
+        tokens.insert(weth_address, "WETH".to_string());
+        
+        // USDC
+        let usdc_address = Address::from_str("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48")
+            .map_err(|e| Error::ValidationError(format!("Invalid address: {}", e)))?;
+        tokens.insert(usdc_address, "USDC".to_string());
+        
+        // USDT
+        let usdt_address = Address::from_str("0xdAC17F958D2ee523a2206206994597C13D831ec7")
+            .map_err(|e| Error::ValidationError(format!("Invalid address: {}", e)))?;
+        tokens.insert(usdt_address, "USDT".to_string());
+        
+        info!("Updated supported tokens. Count: {}", tokens.len());
+        
+        Ok(())
+    }
+    
+    /// イベントをポーリング
+    pub async fn poll_events(&self) -> Result<(), Error> {
+        // 最後に処理したブロック番号を取得
+        let last_block = *self.last_processed_block.read().unwrap();
+        
+        // 最新のブロック番号を取得
+        let latest_block = self.web3.eth().block_number().await
+            .map_err(|e| Error::ConnectionError(format!("Failed to get latest block number: {}", e)))?;
+        
+        let latest_block = latest_block.as_u64();
+        
+        // 処理するブロック範囲を決定（最大1000ブロック）
+        let from_block = last_block + 1;
+        let to_block = std::cmp::min(latest_block, from_block + 999);
+        
+        // 新しいブロックがない場合は終了
+        if from_block > to_block {
+            return Ok(());
+        }
+        
+        info!("Polling events from block {} to {}", from_block, to_block);
+        
+        // デポジットイベントをポーリング
+        self.poll_deposit_events(from_block, to_block).await?;
+        
+        // 引き出しイベントをポーリング
+        self.poll_withdrawal_events(from_block, to_block).await?;
+        
+        // 最後に処理したブロック番号を更新
+        *self.last_processed_block.write().unwrap() = to_block;
+        
+        Ok(())
+    }
+    
+    /// デポジットイベントをポーリング
+    async fn poll_deposit_events(&self, from_block: u64, to_block: u64) -> Result<(), Error> {
+        let contract = self.contract.as_ref()
+            .ok_or_else(|| Error::ContractError("Contract not initialized".to_string()))?;
+        
+        // デポジットイベントのフィルタを作成
+        let filter = FilterBuilder::default()
+            .address(vec![self.contract_address])
+            .from_block(BlockNumber::Number(from_block.into()))
+            .to_block(BlockNumber::Number(to_block.into()))
+            .topics(
+                Some(vec![H256::from_str("0x5548c837ab068cf56a2c2479df0882a4922fd203edb7517321831d95078c5f62").unwrap()]),
+                None,
+                None,
+                None,
+            )
+            .build();
+        
+        // イベントを取得
+        let logs = self.web3.eth().logs(filter).await
+            .map_err(|e| Error::ContractError(format!("Failed to get deposit logs: {}", e)))?;
+        
+        info!("Found {} deposit events", logs.len());
+        
+        // 各イベントを処理
+        for log in logs {
+            self.process_deposit_event(log).await?;
+        }
+        
+        Ok(())
+    }
+    
+    /// デポジットイベントを処理
+    async fn process_deposit_event(&self, log: Log) -> Result<(), Error> {
+        // イベントをデコード
+        let deposit_id = log.topics.get(3)
+            .ok_or_else(|| Error::ContractError("Invalid deposit event format".to_string()))?;
+        
+        // 既に処理済みのイベントはスキップ
+        {
+            let processed_deposits = self.processed_deposits.read().unwrap();
+            if processed_deposits.contains_key(deposit_id) {
+                debug!("Deposit already processed: {:?}", deposit_id);
+                return Ok(());
+            }
+        }
+        
+        // イベントデータをデコード
+        let token = Address::from_slice(&log.topics[1][12..]);
+        let from = Address::from_slice(&log.topics[2][12..]);
+        
+        // データフィールドをデコード
+        let data = log.data.0.clone();
+        if data.len() < 128 {
+            return Err(Error::ContractError("Invalid deposit event data".to_string()));
+        }
+        
+        // ShardXアドレスを取得（文字列）
+        let to_shardx_address_offset = U256::from_big_endian(&data[0..32]).as_usize();
+        let to_shardx_address_length = U256::from_big_endian(&data[to_shardx_address_offset..to_shardx_address_offset+32]).as_usize();
+        let to_shardx_address_start = to_shardx_address_offset + 32;
+        let to_shardx_address_end = to_shardx_address_start + to_shardx_address_length;
+        
+        if to_shardx_address_end > data.len() {
+            return Err(Error::ContractError("Invalid deposit event data".to_string()));
+        }
+        
+        let to_shardx_address = String::from_utf8(data[to_shardx_address_start..to_shardx_address_end].to_vec())
+            .map_err(|e| Error::ContractError(format!("Invalid ShardX address: {}", e)))?;
+        
+        // 金額を取得
+        let amount = U256::from_big_endian(&data[32..64]);
+        
+        info!("Processing deposit: token={}, from={}, to={}, amount={}, id={:?}", 
+            token, from, to_shardx_address, amount, deposit_id);
+        
+        // ShardXでのトランザクションを作成
+        self.create_shardx_deposit_transaction(token, from, to_shardx_address, amount, *deposit_id).await?;
+        
+        // 処理済みとしてマーク
+        {
+            let mut processed_deposits = self.processed_deposits.write().unwrap();
+            processed_deposits.insert(*deposit_id, true);
+        }
+        
+        Ok(())
+    }
+    
+    /// ShardXでのデポジットトランザクションを作成
+    async fn create_shardx_deposit_transaction(
+        &self,
+        token: Address,
+        from: Address,
+        to_shardx_address: String,
+        amount: U256,
+        deposit_id: H256,
+    ) -> Result<(), Error> {
+        // トークンシンボルを取得
+        let token_symbol = {
+            let supported_tokens = self.supported_tokens.read().unwrap();
+            supported_tokens.get(&token)
+                .cloned()
+                .unwrap_or_else(|| "UNKNOWN".to_string())
+        };
+        
+        // ShardXトランザクションを作成
+        let transaction = Transaction {
+            id: format!("eth-deposit-{:?}", deposit_id),
+            from: format!("eth:{}", from),
+            to: to_shardx_address,
+            amount: amount.to_string(),
+            fee: "0".to_string(),
+            data: Some(format!("Ethereum deposit: token={}, from={}, amount={} {}", 
+                token, from, amount, token_symbol)),
+            nonce: 0,
+            timestamp: chrono::Utc::now().timestamp() as u64,
+            signature: format!("eth-bridge:{:?}", deposit_id),
+            status: crate::transaction::TransactionStatus::Pending,
+            shard_id: "shard-1".to_string(),
+            block_hash: None,
+            block_height: None,
+            parent_id: None,
+        };
+        
+        // TODO: ShardXトランザクションを実行
+        info!("Created ShardX transaction for Ethereum deposit: {}", transaction.id);
+        
+        Ok(())
+    }
+    
+    /// 引き出しイベントをポーリング
+    async fn poll_withdrawal_events(&self, from_block: u64, to_block: u64) -> Result<(), Error> {
+        let contract = self.contract.as_ref()
+            .ok_or_else(|| Error::ContractError("Contract not initialized".to_string()))?;
+        
+        // 引き出しイベントのフィルタを作成
+        let filter = FilterBuilder::default()
+            .address(vec![self.contract_address])
+            .from_block(BlockNumber::Number(from_block.into()))
+            .to_block(BlockNumber::Number(to_block.into()))
+            .topics(
+                Some(vec![H256::from_str("0x9b1bfa7fa9ee420a16e124f794c35ac9f90472acc99140eb2f6447c714cad8eb").unwrap()]),
+                None,
+                None,
+                None,
+            )
+            .build();
+        
+        // イベントを取得
+        let logs = self.web3.eth().logs(filter).await
+            .map_err(|e| Error::ContractError(format!("Failed to get withdrawal logs: {}", e)))?;
+        
+        info!("Found {} withdrawal events", logs.len());
+        
+        // 各イベントを処理
+        for log in logs {
+            self.process_withdrawal_event(log).await?;
+        }
+        
+        Ok(())
+    }
+    
+    /// 引き出しイベントを処理
+    async fn process_withdrawal_event(&self, log: Log) -> Result<(), Error> {
+        // イベントをデコード
+        let withdrawal_id = log.topics.get(3)
+            .ok_or_else(|| Error::ContractError("Invalid withdrawal event format".to_string()))?;
+        
+        // 既に処理済みのイベントはスキップ
+        {
+            let processed_withdrawals = self.processed_withdrawals.read().unwrap();
+            if processed_withdrawals.contains_key(withdrawal_id) {
+                debug!("Withdrawal already processed: {:?}", withdrawal_id);
+                return Ok(());
+            }
+        }
+        
+        // イベントデータをデコード
+        let token = Address::from_slice(&log.topics[1][12..]);
+        let to = Address::from_slice(&log.topics[2][12..]);
+        
+        // 金額を取得
+        let amount = U256::from_big_endian(&log.data.0[0..32]);
+        
+        info!("Processing withdrawal: token={}, to={}, amount={}, id={:?}", 
+            token, to, amount, withdrawal_id);
+        
+        // 処理済みとしてマーク
+        {
+            let mut processed_withdrawals = self.processed_withdrawals.write().unwrap();
+            processed_withdrawals.insert(*withdrawal_id, true);
+        }
+        
+        Ok(())
+    }
+    
+    /// ShardXからイーサリアムへの引き出しリクエストを作成
+    pub async fn request_withdrawal(
+        &self,
+        token: Address,
+        recipient: Address,
+        amount: U256,
+        shardx_tx_id: &str,
+    ) -> Result<H256, Error> {
+        let contract = self.contract.as_ref()
+            .ok_or_else(|| Error::ContractError("Contract not initialized".to_string()))?;
+        
+        // 引き出しIDを生成
+        let withdrawal_id = H256::from_slice(&keccak256(
+            format!("{}:{}:{}:{}", token, recipient, amount, shardx_tx_id).as_bytes()
+        ));
+        
+        // コントラクトメソッドを呼び出し
+        let result = contract.call(
+            "requestWithdrawal",
+            (withdrawal_id, token, recipient, amount),
+            self.validator_wallet.address(),
+            Options::default(),
+        ).await.map_err(|e| Error::ContractError(format!("Failed to request withdrawal: {}", e)))?;
+        
+        info!("Requested withdrawal: token={}, recipient={}, amount={}, id={:?}", 
+            token, recipient, amount, withdrawal_id);
+        
+        Ok(withdrawal_id)
+    }
+    
+    /// サポートされているトークンかどうかを確認
+    pub fn is_token_supported(&self, token: Address) -> bool {
+        let supported_tokens = self.supported_tokens.read().unwrap();
+        supported_tokens.contains_key(&token)
+    }
+    
+    /// トークンシンボルを取得
+    pub fn get_token_symbol(&self, token: Address) -> Option<String> {
+        let supported_tokens = self.supported_tokens.read().unwrap();
+        supported_tokens.get(&token).cloned()
+    }
+}
+
+/// keccak256ハッシュを計算
+fn keccak256(data: &[u8]) -> [u8; 32] {
+    use tiny_keccak::{Hasher, Keccak};
+    let mut output = [0u8; 32];
+    let mut hasher = Keccak::v256();
+    hasher.update(data);
+    hasher.finalize(&mut output);
+    output
+}

--- a/src/cross_chain/solana_bridge.rs
+++ b/src/cross_chain/solana_bridge.rs
@@ -1,0 +1,725 @@
+use std::sync::{Arc, RwLock};
+use std::collections::HashMap;
+use std::str::FromStr;
+use tokio::sync::mpsc;
+use tokio::time::{Duration, interval};
+use log::{debug, info, warn, error};
+use serde::{Serialize, Deserialize};
+
+use solana_client::rpc_client::RpcClient;
+use solana_sdk::{
+    commitment_config::CommitmentConfig,
+    pubkey::Pubkey,
+    signature::{Keypair, Signature},
+    signer::Signer,
+    transaction::Transaction as SolanaTransaction,
+    instruction::{Instruction, AccountMeta},
+    system_instruction,
+};
+use solana_program::{
+    program_pack::Pack,
+    system_program,
+};
+use spl_token::{
+    state::{Account as TokenAccount, Mint},
+    instruction as token_instruction,
+};
+use spl_associated_token_account::instruction as associated_token_instruction;
+
+use crate::error::Error;
+use crate::transaction::Transaction;
+use super::bridge::{CrossChainBridge, BridgeConfig, ChainType, BridgeStatus};
+use super::messaging::{CrossChainMessage, MessageType, MessageStatus};
+use super::transaction::{CrossChainTransaction, TransactionStatus, TransactionProof};
+use super::token_registry::{TokenRegistry, TokenInfo};
+
+/// Solanaブリッジ
+pub struct SolanaBridge {
+    /// 基本ブリッジ
+    base_bridge: CrossChainBridge,
+    /// RPCクライアント
+    rpc_client: Option<RpcClient>,
+    /// ウォレット
+    wallet: Option<Keypair>,
+    /// ブリッジプログラムID
+    program_id: Option<Pubkey>,
+    /// トークンレジストリ
+    token_registry: Arc<TokenRegistry>,
+    /// 進行中のクロスチェーントランザクション
+    pending_transactions: RwLock<HashMap<String, CrossChainTransaction>>,
+    /// 処理済みのシグネチャ
+    processed_signatures: RwLock<HashMap<String, bool>>,
+    /// 最後に処理したスロット
+    last_processed_slot: RwLock<u64>,
+    /// イベントポーリングタスクが実行中かどうか
+    polling_active: RwLock<bool>,
+}
+
+/// Solanaブリッジ命令
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub enum SolanaBridgeInstruction {
+    /// トークンをデポジット
+    Deposit {
+        /// 金額
+        amount: u64,
+        /// ShardX宛先アドレス
+        to_shardx_address: String,
+    },
+    /// トークンを引き出し
+    Withdraw {
+        /// 金額
+        amount: u64,
+        /// Solana宛先アドレス
+        to_solana_address: Pubkey,
+    },
+    /// バリデータを追加
+    AddValidator {
+        /// バリデータのアドレス
+        validator: Pubkey,
+    },
+    /// バリデータを削除
+    RemoveValidator {
+        /// バリデータのアドレス
+        validator: Pubkey,
+    },
+    /// サポートするトークンを追加
+    AddSupportedToken {
+        /// トークンのミントアドレス
+        mint: Pubkey,
+    },
+    /// サポートするトークンを削除
+    RemoveSupportedToken {
+        /// トークンのミントアドレス
+        mint: Pubkey,
+    },
+}
+
+impl SolanaBridge {
+    /// 新しいSolanaBridgeを作成
+    pub fn new(
+        config: BridgeConfig,
+        message_sender: mpsc::Sender<CrossChainMessage>,
+        message_receiver: mpsc::Receiver<CrossChainMessage>,
+        token_registry: Arc<TokenRegistry>,
+    ) -> Self {
+        let base_bridge = CrossChainBridge::new(
+            config.clone(),
+            message_sender,
+            message_receiver,
+        );
+        
+        Self {
+            base_bridge,
+            rpc_client: None,
+            wallet: None,
+            program_id: None,
+            token_registry,
+            pending_transactions: RwLock::new(HashMap::new()),
+            processed_signatures: RwLock::new(HashMap::new()),
+            last_processed_slot: RwLock::new(0),
+            polling_active: RwLock::new(false),
+        }
+    }
+    
+    /// ブリッジを初期化
+    pub async fn initialize(&mut self, private_key: &[u8]) -> Result<(), Error> {
+        info!("Initializing Solana bridge: {} -> {}", 
+            self.base_bridge.get_config().source_chain, 
+            self.base_bridge.get_config().target_chain);
+        
+        // RPCクライアントを初期化
+        let endpoint = self.base_bridge.get_config().target_endpoint.clone();
+        let rpc_client = RpcClient::new_with_commitment(endpoint, CommitmentConfig::confirmed());
+        self.rpc_client = Some(rpc_client.clone());
+        
+        // ウォレットを初期化
+        let wallet = Keypair::from_bytes(private_key)
+            .map_err(|e| Error::ValidationError(format!("Invalid private key: {}", e)))?;
+        
+        self.wallet = Some(wallet.clone());
+        
+        // 接続テスト
+        let slot = rpc_client.get_slot()
+            .map_err(|e| Error::ConnectionError(format!("Failed to get slot: {}", e)))?;
+        
+        *self.last_processed_slot.write().unwrap() = slot;
+        
+        info!("Connected to Solana network. Latest slot: {}", slot);
+        
+        // ブリッジプログラムIDを設定
+        let program_id = match &self.base_bridge.get_config().target_contract {
+            Some(addr) => Pubkey::from_str(addr)
+                .map_err(|e| Error::ValidationError(format!("Invalid program ID: {}", e)))?,
+            None => return Err(Error::ValidationError("Bridge program ID not specified".to_string())),
+        };
+        
+        self.program_id = Some(program_id);
+        
+        // 基本ブリッジを初期化
+        self.base_bridge.initialize().await?;
+        
+        // イベントポーリングタスクを開始
+        self.start_event_polling().await?;
+        
+        info!("Solana bridge initialized successfully");
+        
+        Ok(())
+    }
+    
+    /// イベントポーリングタスクを開始
+    async fn start_event_polling(&self) -> Result<(), Error> {
+        // 既に実行中の場合は何もしない
+        {
+            let polling_active = self.polling_active.read().unwrap();
+            if *polling_active {
+                return Ok(());
+            }
+        }
+        
+        // ポーリングアクティブフラグを設定
+        {
+            let mut polling_active = self.polling_active.write().unwrap();
+            *polling_active = true;
+        }
+        
+        // RPCクライアントを取得
+        let rpc_client = match &self.rpc_client {
+            Some(client) => client.clone(),
+            None => return Err(Error::ConnectionError("RPC client not initialized".to_string())),
+        };
+        
+        // プログラムIDを取得
+        let program_id = match self.program_id {
+            Some(id) => id,
+            None => return Err(Error::ValidationError("Program ID not initialized".to_string())),
+        };
+        
+        // ポーリング間隔（5秒）
+        let mut interval = interval(Duration::from_secs(5));
+        
+        // ポーリングタスクを開始
+        let last_processed_slot = self.last_processed_slot.clone();
+        let processed_signatures = self.processed_signatures.clone();
+        let pending_transactions = self.pending_transactions.clone();
+        let polling_active = self.polling_active.clone();
+        
+        tokio::spawn(async move {
+            loop {
+                interval.tick().await;
+                
+                // ポーリングが無効化された場合は終了
+                {
+                    let polling_active_guard = polling_active.read().unwrap();
+                    if !*polling_active_guard {
+                        break;
+                    }
+                }
+                
+                // 最新のスロットを取得
+                let current_slot = match rpc_client.get_slot() {
+                    Ok(slot) => slot,
+                    Err(e) => {
+                        error!("Failed to get current slot: {}", e);
+                        continue;
+                    }
+                };
+                
+                // 最後に処理したスロットを取得
+                let last_slot = {
+                    let last_slot = last_processed_slot.read().unwrap();
+                    *last_slot
+                };
+                
+                // 新しいスロットがない場合はスキップ
+                if current_slot <= last_slot {
+                    continue;
+                }
+                
+                // プログラムの署名を取得
+                let signatures = match rpc_client.get_signatures_for_address(
+                    &program_id,
+                    Some(last_slot),
+                    Some(current_slot),
+                    CommitmentConfig::confirmed(),
+                ) {
+                    Ok(sigs) => sigs,
+                    Err(e) => {
+                        error!("Failed to get signatures: {}", e);
+                        continue;
+                    }
+                };
+                
+                // 各署名を処理
+                for sig_info in signatures {
+                    let signature_str = sig_info.signature.to_string();
+                    
+                    // 既に処理済みの署名はスキップ
+                    {
+                        let processed_signatures_guard = processed_signatures.read().unwrap();
+                        if processed_signatures_guard.contains_key(&signature_str) {
+                            continue;
+                        }
+                    }
+                    
+                    // トランザクション情報を取得
+                    let tx_info = match rpc_client.get_transaction(
+                        &sig_info.signature,
+                        CommitmentConfig::confirmed(),
+                    ) {
+                        Ok(info) => info,
+                        Err(e) => {
+                            error!("Failed to get transaction info: {}", e);
+                            continue;
+                        }
+                    };
+                    
+                    // TODO: トランザクションを解析してデポジットイベントを検出
+                    // 実際の実装では、トランザクションのログを解析してデポジットイベントを検出する
+                    
+                    // 処理済みとしてマーク
+                    {
+                        let mut processed_signatures_guard = processed_signatures.write().unwrap();
+                        processed_signatures_guard.insert(signature_str, true);
+                    }
+                }
+                
+                // 最後に処理したスロットを更新
+                {
+                    let mut last_slot_guard = last_processed_slot.write().unwrap();
+                    *last_slot_guard = current_slot;
+                }
+                
+                // 保留中のトランザクションを処理
+                let tx_ids: Vec<String> = {
+                    let pending_transactions_guard = pending_transactions.read().unwrap();
+                    pending_transactions_guard.keys().cloned().collect()
+                };
+                
+                for tx_id in tx_ids {
+                    // トランザクションを取得
+                    let tx = {
+                        let pending_transactions_guard = pending_transactions.read().unwrap();
+                        match pending_transactions_guard.get(&tx_id) {
+                            Some(tx) => tx.clone(),
+                            None => continue,
+                        }
+                    };
+                    
+                    // Solanaトランザクションシグネチャを取得
+                    let signature = match tx.get_metadata("solana_signature") {
+                        Some(sig) => sig,
+                        None => continue,
+                    };
+                    
+                    // トランザクションの状態を確認
+                    let signature_obj = match Signature::from_str(signature) {
+                        Ok(sig) => sig,
+                        Err(_) => continue,
+                    };
+                    
+                    let status = match rpc_client.get_signature_status(&signature_obj) {
+                        Ok(Some(status)) => status,
+                        Ok(None) => continue, // まだ処理中
+                        Err(_) => continue,
+                    };
+                    
+                    // トランザクションの状態を更新
+                    let mut updated_tx = tx.clone();
+                    
+                    if status.is_ok() {
+                        // 成功
+                        updated_tx.status = TransactionStatus::Confirmed;
+                        
+                        // トランザクション情報を取得
+                        if let Ok(tx_info) = rpc_client.get_transaction(
+                            &signature_obj,
+                            CommitmentConfig::confirmed(),
+                        ) {
+                            // ブロック情報を設定
+                            updated_tx.set_target_block_info(
+                                tx_info.transaction.signatures[0].to_string(),
+                                tx_info.slot,
+                            );
+                        }
+                        
+                        // 保留中のトランザクションから削除
+                        {
+                            let mut pending_transactions_guard = pending_transactions.write().unwrap();
+                            pending_transactions_guard.remove(&tx_id);
+                        }
+                    } else {
+                        // 失敗
+                        updated_tx.mark_as_failed(format!("Transaction failed: {:?}", status));
+                        
+                        // 保留中のトランザクションから削除
+                        {
+                            let mut pending_transactions_guard = pending_transactions.write().unwrap();
+                            pending_transactions_guard.remove(&tx_id);
+                        }
+                    }
+                    
+                    // TODO: トランザクションの状態を更新
+                    // 実際の実装では、基本ブリッジのトランザクションマップを更新する
+                }
+            }
+        });
+        
+        info!("Event polling task started");
+        
+        Ok(())
+    }
+    
+    /// イベントポーリングタスクを停止
+    pub fn stop_event_polling(&self) {
+        let mut polling_active = self.polling_active.write().unwrap();
+        *polling_active = false;
+        info!("Event polling task stopped");
+    }
+    
+    /// ShardXからSolanaへのトークン転送
+    pub async fn transfer_to_solana(
+        &self,
+        token_id: &str,
+        recipient: &str,
+        amount: &str,
+        from_address: &str,
+    ) -> Result<String, Error> {
+        // トークン情報を取得
+        let token = match self.token_registry.get_token(token_id) {
+            Some(token) => token,
+            None => return Err(Error::ValidationError(format!("Token not found: {}", token_id))),
+        };
+        
+        // トークンがSolanaチェーンのものであることを確認
+        if token.chain_type != ChainType::Solana {
+            return Err(Error::ValidationError(format!("Token is not on Solana chain: {}", token_id)));
+        }
+        
+        // 受取人アドレスを検証
+        let recipient_pubkey = Pubkey::from_str(recipient)
+            .map_err(|e| Error::ValidationError(format!("Invalid recipient address: {}", e)))?;
+        
+        // 金額を検証
+        let amount_u64 = amount.parse::<u64>()
+            .map_err(|e| Error::ValidationError(format!("Invalid amount: {}", e)))?;
+        
+        // トークンミントアドレスを取得
+        let mint_pubkey = Pubkey::from_str(&token.chain_address)
+            .map_err(|e| Error::ValidationError(format!("Invalid token address: {}", e)))?;
+        
+        // RPCクライアントを取得
+        let rpc_client = match &self.rpc_client {
+            Some(client) => client,
+            None => return Err(Error::ConnectionError("RPC client not initialized".to_string())),
+        };
+        
+        // ウォレットを取得
+        let wallet = match &self.wallet {
+            Some(wallet) => wallet,
+            None => return Err(Error::ValidationError("Wallet not initialized".to_string())),
+        };
+        
+        // プログラムIDを取得
+        let program_id = match self.program_id {
+            Some(id) => id,
+            None => return Err(Error::ValidationError("Program ID not initialized".to_string())),
+        };
+        
+        // ブリッジのトークンアカウントを取得
+        let bridge_token_account = spl_associated_token_account::get_associated_token_address(
+            &program_id,
+            &mint_pubkey,
+        );
+        
+        // 引き出し命令を作成
+        let instruction_data = bincode::serialize(&SolanaBridgeInstruction::Withdraw {
+            amount: amount_u64,
+            to_solana_address: recipient_pubkey,
+        }).map_err(|e| Error::SerializationError(e.to_string()))?;
+        
+        // 命令を作成
+        let instruction = Instruction {
+            program_id,
+            accounts: vec![
+                AccountMeta::new(wallet.pubkey(), true),
+                AccountMeta::new(bridge_token_account, false),
+                AccountMeta::new(recipient_pubkey, false),
+                AccountMeta::new_readonly(mint_pubkey, false),
+                AccountMeta::new_readonly(spl_token::id(), false),
+                AccountMeta::new_readonly(spl_associated_token_account::id(), false),
+                AccountMeta::new_readonly(system_program::id(), false),
+            ],
+            data: instruction_data,
+        };
+        
+        // トランザクションを作成
+        let blockhash = rpc_client.get_latest_blockhash()
+            .map_err(|e| Error::TransactionError(format!("Failed to get blockhash: {}", e)))?;
+        
+        let transaction = SolanaTransaction::new_signed_with_payer(
+            &[instruction],
+            Some(&wallet.pubkey()),
+            &[wallet],
+            blockhash,
+        );
+        
+        // トランザクションを送信
+        let signature = rpc_client.send_transaction(&transaction)
+            .map_err(|e| Error::TransactionError(format!("Failed to send transaction: {}", e)))?;
+        
+        // トランザクションIDを生成
+        let tx_id = uuid::Uuid::new_v4().to_string();
+        
+        // クロスチェーントランザクションを作成
+        let cross_tx = CrossChainTransaction::new(
+            Transaction {
+                id: tx_id.clone(),
+                from: from_address.to_string(),
+                to: recipient.to_string(),
+                amount: amount.to_string(),
+                fee: "0".to_string(),
+                data: Some(format!("Transfer to Solana: token={}, recipient={}", token.symbol, recipient)),
+                nonce: 0,
+                timestamp: chrono::Utc::now().timestamp() as u64,
+                signature: "".to_string(),
+                status: crate::transaction::TransactionStatus::Pending,
+                shard_id: "shard-1".to_string(),
+                block_hash: None,
+                block_height: None,
+                parent_id: None,
+            },
+            ChainType::ShardX,
+            ChainType::Solana,
+        );
+        
+        // メタデータを設定
+        let mut updated_tx = cross_tx.clone();
+        updated_tx.set_metadata("token_id".to_string(), token_id.to_string());
+        updated_tx.set_metadata("token_symbol".to_string(), token.symbol);
+        updated_tx.set_metadata("solana_signature".to_string(), signature.to_string());
+        
+        // 保留中のトランザクションに追加
+        {
+            let mut pending_transactions = self.pending_transactions.write().unwrap();
+            pending_transactions.insert(tx_id.clone(), updated_tx.clone());
+        }
+        
+        info!("Created cross-chain transaction from ShardX to Solana: {}", tx_id);
+        
+        Ok(tx_id)
+    }
+    
+    /// SolanaからShardXへのトークン転送
+    pub async fn transfer_from_solana(
+        &self,
+        token_id: &str,
+        shardx_recipient: &str,
+        amount: &str,
+    ) -> Result<String, Error> {
+        // トークン情報を取得
+        let token = match self.token_registry.get_token(token_id) {
+            Some(token) => token,
+            None => return Err(Error::ValidationError(format!("Token not found: {}", token_id))),
+        };
+        
+        // トークンがSolanaチェーンのものであることを確認
+        if token.chain_type != ChainType::Solana {
+            return Err(Error::ValidationError(format!("Token is not on Solana chain: {}", token_id)));
+        }
+        
+        // ShardX受取人アドレスを検証
+        if shardx_recipient.is_empty() {
+            return Err(Error::ValidationError("Invalid ShardX recipient address".to_string()));
+        }
+        
+        // 金額を検証
+        let amount_u64 = amount.parse::<u64>()
+            .map_err(|e| Error::ValidationError(format!("Invalid amount: {}", e)))?;
+        
+        // トークンミントアドレスを取得
+        let mint_pubkey = Pubkey::from_str(&token.chain_address)
+            .map_err(|e| Error::ValidationError(format!("Invalid token address: {}", e)))?;
+        
+        // RPCクライアントを取得
+        let rpc_client = match &self.rpc_client {
+            Some(client) => client,
+            None => return Err(Error::ConnectionError("RPC client not initialized".to_string())),
+        };
+        
+        // ウォレットを取得
+        let wallet = match &self.wallet {
+            Some(wallet) => wallet,
+            None => return Err(Error::ValidationError("Wallet not initialized".to_string())),
+        };
+        
+        // プログラムIDを取得
+        let program_id = match self.program_id {
+            Some(id) => id,
+            None => return Err(Error::ValidationError("Program ID not initialized".to_string())),
+        };
+        
+        // 送信者のトークンアカウントを取得
+        let sender_token_account = spl_associated_token_account::get_associated_token_address(
+            &wallet.pubkey(),
+            &mint_pubkey,
+        );
+        
+        // ブリッジのトークンアカウントを取得
+        let bridge_token_account = spl_associated_token_account::get_associated_token_address(
+            &program_id,
+            &mint_pubkey,
+        );
+        
+        // ブリッジのトークンアカウントが存在するか確認
+        let bridge_account_exists = rpc_client.get_account_data(&bridge_token_account).is_ok();
+        
+        // ブリッジのトークンアカウントが存在しない場合は作成
+        let mut instructions = Vec::new();
+        
+        if !bridge_account_exists {
+            instructions.push(
+                associated_token_instruction::create_associated_token_account(
+                    &wallet.pubkey(),
+                    &program_id,
+                    &mint_pubkey,
+                ),
+            );
+        }
+        
+        // デポジット命令を作成
+        let instruction_data = bincode::serialize(&SolanaBridgeInstruction::Deposit {
+            amount: amount_u64,
+            to_shardx_address: shardx_recipient.to_string(),
+        }).map_err(|e| Error::SerializationError(e.to_string()))?;
+        
+        // トークン転送命令を作成
+        instructions.push(
+            token_instruction::transfer(
+                &spl_token::id(),
+                &sender_token_account,
+                &bridge_token_account,
+                &wallet.pubkey(),
+                &[&wallet.pubkey()],
+                amount_u64,
+            ).map_err(|e| Error::TransactionError(format!("Failed to create transfer instruction: {}", e)))?
+        );
+        
+        // デポジット命令を作成
+        instructions.push(
+            Instruction {
+                program_id,
+                accounts: vec![
+                    AccountMeta::new(wallet.pubkey(), true),
+                    AccountMeta::new(sender_token_account, false),
+                    AccountMeta::new(bridge_token_account, false),
+                    AccountMeta::new_readonly(mint_pubkey, false),
+                    AccountMeta::new_readonly(spl_token::id(), false),
+                ],
+                data: instruction_data,
+            }
+        );
+        
+        // トランザクションを作成
+        let blockhash = rpc_client.get_latest_blockhash()
+            .map_err(|e| Error::TransactionError(format!("Failed to get blockhash: {}", e)))?;
+        
+        let transaction = SolanaTransaction::new_signed_with_payer(
+            &instructions,
+            Some(&wallet.pubkey()),
+            &[wallet],
+            blockhash,
+        );
+        
+        // トランザクションを送信
+        let signature = rpc_client.send_transaction(&transaction)
+            .map_err(|e| Error::TransactionError(format!("Failed to send transaction: {}", e)))?;
+        
+        // トランザクションIDを生成
+        let tx_id = uuid::Uuid::new_v4().to_string();
+        
+        // クロスチェーントランザクションを作成
+        let cross_tx = CrossChainTransaction::new(
+            Transaction {
+                id: tx_id.clone(),
+                from: wallet.pubkey().to_string(),
+                to: shardx_recipient.to_string(),
+                amount: amount.to_string(),
+                fee: "0".to_string(),
+                data: Some(format!("Transfer from Solana: token={}", token.symbol)),
+                nonce: 0,
+                timestamp: chrono::Utc::now().timestamp() as u64,
+                signature: "".to_string(),
+                status: crate::transaction::TransactionStatus::Pending,
+                shard_id: "shard-1".to_string(),
+                block_hash: None,
+                block_height: None,
+                parent_id: None,
+            },
+            ChainType::Solana,
+            ChainType::ShardX,
+        );
+        
+        // メタデータを設定
+        let mut updated_tx = cross_tx.clone();
+        updated_tx.set_metadata("token_id".to_string(), token_id.to_string());
+        updated_tx.set_metadata("token_symbol".to_string(), token.symbol);
+        updated_tx.set_metadata("solana_signature".to_string(), signature.to_string());
+        
+        // 保留中のトランザクションに追加
+        {
+            let mut pending_transactions = self.pending_transactions.write().unwrap();
+            pending_transactions.insert(tx_id.clone(), updated_tx.clone());
+        }
+        
+        info!("Created cross-chain transaction from Solana to ShardX: {}", tx_id);
+        
+        Ok(tx_id)
+    }
+    
+    /// トランザクションの状態を取得
+    pub fn get_transaction_status(&self, tx_id: &str) -> Result<TransactionStatus, Error> {
+        // 保留中のトランザクションから検索
+        {
+            let pending_transactions = self.pending_transactions.read().unwrap();
+            if let Some(tx) = pending_transactions.get(tx_id) {
+                return Ok(tx.status);
+            }
+        }
+        
+        // 基本ブリッジから検索
+        self.base_bridge.get_transaction_status(tx_id)
+    }
+    
+    /// トランザクションの詳細を取得
+    pub fn get_transaction_details(&self, tx_id: &str) -> Result<CrossChainTransaction, Error> {
+        // 保留中のトランザクションから検索
+        {
+            let pending_transactions = self.pending_transactions.read().unwrap();
+            if let Some(tx) = pending_transactions.get(tx_id) {
+                return Ok(tx.clone());
+            }
+        }
+        
+        // 基本ブリッジから検索
+        self.base_bridge.get_transaction_details(tx_id)
+    }
+    
+    /// ブリッジの状態を取得
+    pub fn get_status(&self) -> BridgeStatus {
+        self.base_bridge.get_status()
+    }
+    
+    /// ブリッジの設定を取得
+    pub fn get_config(&self) -> BridgeConfig {
+        self.base_bridge.get_config()
+    }
+    
+    /// ブリッジを停止
+    pub async fn shutdown(&self) -> Result<(), Error> {
+        // イベントポーリングを停止
+        self.stop_event_polling();
+        
+        // 基本ブリッジを停止
+        self.base_bridge.shutdown().await
+    }
+}

--- a/src/cross_chain/token_registry.rs
+++ b/src/cross_chain/token_registry.rs
@@ -1,0 +1,334 @@
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+use serde::{Serialize, Deserialize};
+use log::{debug, info, warn, error};
+
+use crate::error::Error;
+use super::bridge::ChainType;
+
+/// トークン情報
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TokenInfo {
+    /// トークンID
+    pub id: String,
+    /// トークン名
+    pub name: String,
+    /// トークンシンボル
+    pub symbol: String,
+    /// 小数点以下の桁数
+    pub decimals: u8,
+    /// チェーンタイプ
+    pub chain_type: ChainType,
+    /// チェーン固有のアドレス/識別子
+    pub chain_address: String,
+    /// 総供給量
+    pub total_supply: Option<String>,
+    /// アイコンURL
+    pub icon_url: Option<String>,
+    /// プロジェクトURL
+    pub project_url: Option<String>,
+    /// 説明
+    pub description: Option<String>,
+    /// メタデータ
+    pub metadata: HashMap<String, String>,
+}
+
+impl TokenInfo {
+    /// 新しいトークン情報を作成
+    pub fn new(
+        id: String,
+        name: String,
+        symbol: String,
+        decimals: u8,
+        chain_type: ChainType,
+        chain_address: String,
+    ) -> Self {
+        Self {
+            id,
+            name,
+            symbol,
+            decimals,
+            chain_type,
+            chain_address,
+            total_supply: None,
+            icon_url: None,
+            project_url: None,
+            description: None,
+            metadata: HashMap::new(),
+        }
+    }
+    
+    /// メタデータを設定
+    pub fn set_metadata(&mut self, key: String, value: String) {
+        self.metadata.insert(key, value);
+    }
+    
+    /// メタデータを取得
+    pub fn get_metadata(&self, key: &str) -> Option<&String> {
+        self.metadata.get(key)
+    }
+}
+
+/// トークンレジストリ
+pub struct TokenRegistry {
+    /// トークンマップ (トークンID -> トークン情報)
+    tokens: RwLock<HashMap<String, TokenInfo>>,
+    /// チェーンアドレスマップ (チェーンタイプ, チェーンアドレス) -> トークンID
+    chain_address_map: RwLock<HashMap<(ChainType, String), String>>,
+    /// シンボルマップ (シンボル -> トークンID)
+    symbol_map: RwLock<HashMap<String, Vec<String>>>,
+}
+
+impl TokenRegistry {
+    /// 新しいトークンレジストリを作成
+    pub fn new() -> Self {
+        Self {
+            tokens: RwLock::new(HashMap::new()),
+            chain_address_map: RwLock::new(HashMap::new()),
+            symbol_map: RwLock::new(HashMap::new()),
+        }
+    }
+    
+    /// トークンを登録
+    pub fn register_token(&self, token: TokenInfo) -> Result<(), Error> {
+        let token_id = token.id.clone();
+        let chain_type = token.chain_type;
+        let chain_address = token.chain_address.clone();
+        let symbol = token.symbol.clone();
+        
+        // トークンを追加
+        {
+            let mut tokens = self.tokens.write().unwrap();
+            if tokens.contains_key(&token_id) {
+                return Err(Error::ValidationError(format!("Token already registered: {}", token_id)));
+            }
+            tokens.insert(token_id.clone(), token);
+        }
+        
+        // チェーンアドレスマップを更新
+        {
+            let mut chain_address_map = self.chain_address_map.write().unwrap();
+            chain_address_map.insert((chain_type, chain_address), token_id.clone());
+        }
+        
+        // シンボルマップを更新
+        {
+            let mut symbol_map = self.symbol_map.write().unwrap();
+            let token_ids = symbol_map.entry(symbol).or_insert_with(Vec::new);
+            token_ids.push(token_id);
+        }
+        
+        Ok(())
+    }
+    
+    /// トークンを取得
+    pub fn get_token(&self, token_id: &str) -> Option<TokenInfo> {
+        let tokens = self.tokens.read().unwrap();
+        tokens.get(token_id).cloned()
+    }
+    
+    /// チェーンアドレスからトークンを取得
+    pub fn get_token_by_chain_address(&self, chain_type: ChainType, chain_address: &str) -> Option<TokenInfo> {
+        let chain_address_map = self.chain_address_map.read().unwrap();
+        let token_id = chain_address_map.get(&(chain_type, chain_address.to_string()))?;
+        
+        let tokens = self.tokens.read().unwrap();
+        tokens.get(token_id).cloned()
+    }
+    
+    /// シンボルからトークンを取得
+    pub fn get_tokens_by_symbol(&self, symbol: &str) -> Vec<TokenInfo> {
+        let symbol_map = self.symbol_map.read().unwrap();
+        let token_ids = match symbol_map.get(symbol) {
+            Some(ids) => ids,
+            None => return Vec::new(),
+        };
+        
+        let tokens = self.tokens.read().unwrap();
+        token_ids.iter()
+            .filter_map(|id| tokens.get(id).cloned())
+            .collect()
+    }
+    
+    /// すべてのトークンを取得
+    pub fn get_all_tokens(&self) -> Vec<TokenInfo> {
+        let tokens = self.tokens.read().unwrap();
+        tokens.values().cloned().collect()
+    }
+    
+    /// チェーンタイプのトークンをすべて取得
+    pub fn get_tokens_by_chain(&self, chain_type: ChainType) -> Vec<TokenInfo> {
+        let tokens = self.tokens.read().unwrap();
+        tokens.values()
+            .filter(|token| token.chain_type == chain_type)
+            .cloned()
+            .collect()
+    }
+    
+    /// トークンを削除
+    pub fn remove_token(&self, token_id: &str) -> Result<(), Error> {
+        // トークンを取得
+        let token = {
+            let tokens = self.tokens.read().unwrap();
+            match tokens.get(token_id) {
+                Some(token) => token.clone(),
+                None => return Err(Error::ValidationError(format!("Token not found: {}", token_id))),
+            }
+        };
+        
+        // トークンを削除
+        {
+            let mut tokens = self.tokens.write().unwrap();
+            tokens.remove(token_id);
+        }
+        
+        // チェーンアドレスマップを更新
+        {
+            let mut chain_address_map = self.chain_address_map.write().unwrap();
+            chain_address_map.remove(&(token.chain_type, token.chain_address));
+        }
+        
+        // シンボルマップを更新
+        {
+            let mut symbol_map = self.symbol_map.write().unwrap();
+            if let Some(token_ids) = symbol_map.get_mut(&token.symbol) {
+                token_ids.retain(|id| id != token_id);
+                if token_ids.is_empty() {
+                    symbol_map.remove(&token.symbol);
+                }
+            }
+        }
+        
+        Ok(())
+    }
+    
+    /// トークンを更新
+    pub fn update_token(&self, token: TokenInfo) -> Result<(), Error> {
+        let token_id = token.id.clone();
+        
+        // 既存のトークンを取得
+        let old_token = {
+            let tokens = self.tokens.read().unwrap();
+            match tokens.get(&token_id) {
+                Some(token) => token.clone(),
+                None => return Err(Error::ValidationError(format!("Token not found: {}", token_id))),
+            }
+        };
+        
+        // チェーンアドレスが変更された場合、チェーンアドレスマップを更新
+        if old_token.chain_type != token.chain_type || old_token.chain_address != token.chain_address {
+            let mut chain_address_map = self.chain_address_map.write().unwrap();
+            chain_address_map.remove(&(old_token.chain_type, old_token.chain_address));
+            chain_address_map.insert((token.chain_type, token.chain_address.clone()), token_id.clone());
+        }
+        
+        // シンボルが変更された場合、シンボルマップを更新
+        if old_token.symbol != token.symbol {
+            let mut symbol_map = self.symbol_map.write().unwrap();
+            
+            // 古いシンボルから削除
+            if let Some(token_ids) = symbol_map.get_mut(&old_token.symbol) {
+                token_ids.retain(|id| id != &token_id);
+                if token_ids.is_empty() {
+                    symbol_map.remove(&old_token.symbol);
+                }
+            }
+            
+            // 新しいシンボルに追加
+            let token_ids = symbol_map.entry(token.symbol.clone()).or_insert_with(Vec::new);
+            token_ids.push(token_id.clone());
+        }
+        
+        // トークンを更新
+        {
+            let mut tokens = self.tokens.write().unwrap();
+            tokens.insert(token_id, token);
+        }
+        
+        Ok(())
+    }
+    
+    /// デフォルトのトークンを登録
+    pub fn register_default_tokens(&self) -> Result<(), Error> {
+        // ShardX ネイティブトークン
+        let shardx_token = TokenInfo::new(
+            "shardx-native".to_string(),
+            "ShardX".to_string(),
+            "SHX".to_string(),
+            18,
+            ChainType::ShardX,
+            "native".to_string(),
+        );
+        self.register_token(shardx_token)?;
+        
+        // Ethereum (ETH)
+        let eth_token = TokenInfo::new(
+            "ethereum-eth".to_string(),
+            "Ethereum".to_string(),
+            "ETH".to_string(),
+            18,
+            ChainType::Ethereum,
+            "0x0000000000000000000000000000000000000000".to_string(),
+        );
+        self.register_token(eth_token)?;
+        
+        // Wrapped Ethereum (WETH)
+        let weth_token = TokenInfo::new(
+            "ethereum-weth".to_string(),
+            "Wrapped Ethereum".to_string(),
+            "WETH".to_string(),
+            18,
+            ChainType::Ethereum,
+            "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2".to_string(),
+        );
+        self.register_token(weth_token)?;
+        
+        // USDC on Ethereum
+        let usdc_token = TokenInfo::new(
+            "ethereum-usdc".to_string(),
+            "USD Coin".to_string(),
+            "USDC".to_string(),
+            6,
+            ChainType::Ethereum,
+            "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48".to_string(),
+        );
+        self.register_token(usdc_token)?;
+        
+        // USDT on Ethereum
+        let usdt_token = TokenInfo::new(
+            "ethereum-usdt".to_string(),
+            "Tether USD".to_string(),
+            "USDT".to_string(),
+            6,
+            ChainType::Ethereum,
+            "0xdAC17F958D2ee523a2206206994597C13D831ec7".to_string(),
+        );
+        self.register_token(usdt_token)?;
+        
+        // Solana (SOL)
+        let sol_token = TokenInfo::new(
+            "solana-sol".to_string(),
+            "Solana".to_string(),
+            "SOL".to_string(),
+            9,
+            ChainType::Solana,
+            "native".to_string(),
+        );
+        self.register_token(sol_token)?;
+        
+        // USDC on Solana
+        let solana_usdc_token = TokenInfo::new(
+            "solana-usdc".to_string(),
+            "USD Coin".to_string(),
+            "USDC".to_string(),
+            6,
+            ChainType::Solana,
+            "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v".to_string(),
+        );
+        self.register_token(solana_usdc_token)?;
+        
+        info!("Registered default tokens");
+        
+        Ok(())
+    }
+}


### PR DESCRIPTION
このPRでは、ShardXを複数のクラウドプラットフォームに簡単にデプロイするための機能を追加しています：

- Render、Railway、Heroku、Fly.ioへのワンクリックデプロイボタン
- 各プラットフォーム用の最適化された設定ファイル
- デプロイスクリプトの追加（deploy-render.sh, deploy-railway.sh, deploy-heroku.sh, deploy-fly.sh）
- 詳細なマルチプラットフォームデプロイガイドの追加
- READMEの更新とデプロイオプションの説明

これにより、ユーザーは好みのクラウドプラットフォームを選択して、数クリックでShardXを起動できるようになります。各プラットフォームはRPCノードとWebインターフェースの両方を自動的に設定します。