### PR TITLE
Fix Render deployment configuration

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -4,7 +4,6 @@ primary_region = "nrt"
 
 [build]
   dockerfile = "Dockerfile"
-  builder = "dockerfile"
 
 [env]
   NODE_ID = "fly_node"
@@ -16,50 +15,41 @@ primary_region = "nrt"
   PORT = "54868"
   P2P_PORT = "54867"
 
-[http_service]
+[http]
   internal_port = 54868
   force_https = true
-  auto_stop_machines = false
-  auto_start_machines = true
-  min_machines_running = 1
+
+[[services]]
+  protocol = "tcp"
+  internal_port = 54868
   processes = ["app"]
 
-[services]
-  [services.web]
-    protocol = "tcp"
-    internal_port = 54868
-    processes = ["app"]
+  [[services.ports]]
+    port = 80
+    handlers = ["http"]
+    force_https = true
 
-    [[services.web.ports]]
-      port = 80
-      handlers = ["http"]
-      force_https = true
+  [[services.ports]]
+    port = 443
+    handlers = ["tls", "http"]
 
-    [[services.web.ports]]
-      port = 443
-      handlers = ["tls", "http"]
+  [services.concurrency]
+    type = "connections"
+    hard_limit = 1000
+    soft_limit = 500
 
-    [services.web.concurrency]
-      type = "connections"
-      hard_limit = 1000
-      soft_limit = 500
+[[services]]
+  protocol = "tcp"
+  internal_port = 54867
+  processes = ["app"]
 
-  [services.p2p]
-    protocol = "tcp"
-    internal_port = 54867
-    processes = ["app"]
-
-    [[services.p2p.ports]]
-      port = 54867
-      handlers = ["tcp"]
+  [[services.ports]]
+    port = 54867
+    handlers = ["tcp"]
 
 [mounts]
   source = "shardx_data"
   destination = "/app/data"
-
-[metrics]
-  port = 9091
-  path = "/metrics"
 
 [[vm]]
   memory = "1gb"

--- a/fly.toml
+++ b/fly.toml
@@ -4,6 +4,7 @@ primary_region = "nrt"
 
 [build]
   dockerfile = "Dockerfile"
+  builder = "dockerfile"
 
 [env]
   NODE_ID = "fly_node"

--- a/render.yaml
+++ b/render.yaml
@@ -32,10 +32,6 @@ services:
     env: node
     buildCommand: cd web && npm install && npm run build
     startCommand: cd web && npm start
-    headers:
-      - path: /*
-        name: Access-Control-Allow-Origin
-        value: "*"
     envVars:
       - key: PORT
         value: 52153
@@ -43,6 +39,8 @@ services:
         value: https://shardx-node.onrender.com
       - key: NODE_ENV
         value: production
+      - key: CORS_ENABLED
+        value: "true"
 
   # Redis（キャッシュとメッセージングに使用）
   - type: redis

--- a/scripts/deploy-fly-fix.sh
+++ b/scripts/deploy-fly-fix.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+set -e
+
+# ShardXをFly.ioにデプロイするスクリプト（修正版）
+
+# 色の定義
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+echo -e "${BLUE}=== ShardX Fly.ioデプロイスクリプト（修正版） ===${NC}"
+echo
+
+# Fly CLIがインストールされているか確認
+if ! command -v flyctl &> /dev/null; then
+    echo -e "${RED}Fly CLIがインストールされていません。${NC}"
+    echo "インストール方法: curl -L https://fly.io/install.sh | sh"
+    
+    # インストールを試みる
+    read -p "Fly CLIをインストールしますか？ (y/n): " INSTALL_CLI
+    if [[ "$INSTALL_CLI" == "y" || "$INSTALL_CLI" == "Y" ]]; then
+        echo -e "${BLUE}Fly CLIをインストールしています...${NC}"
+        curl -L https://fly.io/install.sh | sh
+        
+        # PATHを更新
+        export PATH=$HOME/.fly/bin:$PATH
+    else
+        echo -e "${RED}Fly CLIが必要です。インストール後に再実行してください。${NC}"
+        exit 1
+    fi
+fi
+
+# ログイン状態を確認
+if ! flyctl auth whoami &> /dev/null; then
+    echo -e "${BLUE}Fly.ioにログインしてください...${NC}"
+    flyctl auth login
+fi
+
+# アプリ名を取得
+read -p "Fly.ioアプリ名を入力してください (例: shardx-app): " APP_NAME
+
+# リージョンを選択
+echo -e "${BLUE}デプロイするリージョンを選択してください:${NC}"
+echo "1) Tokyo (nrt)"
+echo "2) Singapore (sin)"
+echo "3) Los Angeles (lax)"
+echo "4) New York (ewr)"
+echo "5) London (lhr)"
+read -p "リージョン番号を選択してください (1-5): " REGION_NUM
+
+case $REGION_NUM in
+    1) REGION="nrt" ;;
+    2) REGION="sin" ;;
+    3) REGION="lax" ;;
+    4) REGION="ewr" ;;
+    5) REGION="lhr" ;;
+    *) REGION="nrt" ;;
+esac
+
+# 一時的な設定ファイルを作成
+echo -e "${BLUE}設定ファイルを作成しています...${NC}"
+cat > fly.toml.new << EOL
+# fly.toml - Fly.io設定ファイル
+app = "${APP_NAME}"
+primary_region = "${REGION}"
+
+[build]
+  dockerfile = "Dockerfile"
+  builder = "dockerfile"
+
+[env]
+  NODE_ID = "fly_node"
+  RUST_LOG = "info"
+  INITIAL_SHARDS = "64"
+  DATA_DIR = "/app/data"
+  REDIS_ENABLED = "true"
+  WEB_ENABLED = "true"
+  PORT = "54868"
+  P2P_PORT = "54867"
+
+[http_service]
+  internal_port = 54868
+  force_https = true
+  auto_stop_machines = false
+  auto_start_machines = true
+  min_machines_running = 1
+  processes = ["app"]
+
+[[services]]
+  protocol = "tcp"
+  internal_port = 54868
+  processes = ["app"]
+
+  [[services.ports]]
+    port = 80
+    handlers = ["http"]
+    force_https = true
+
+  [[services.ports]]
+    port = 443
+    handlers = ["tls", "http"]
+
+  [services.concurrency]
+    type = "connections"
+    hard_limit = 1000
+    soft_limit = 500
+
+[[services]]
+  protocol = "tcp"
+  internal_port = 54867
+  processes = ["app"]
+
+  [[services.ports]]
+    port = 54867
+    handlers = ["tcp"]
+
+[mounts]
+  source = "shardx_data"
+  destination = "/app/data"
+
+[metrics]
+  port = 9091
+  path = "/metrics"
+
+[[vm]]
+  memory = "1gb"
+  cpu_kind = "shared"
+  cpus = 1
+EOL
+
+# 設定ファイルを置き換え
+mv fly.toml.new fly.toml
+
+# アプリを作成
+echo -e "${BLUE}Fly.ioアプリを作成しています...${NC}"
+flyctl apps create "$APP_NAME" --json || echo "アプリは既に存在します"
+
+# ボリュームを作成
+echo -e "${BLUE}永続ボリュームを作成しています...${NC}"
+flyctl volumes create shardx_data --region "$REGION" --size 1 --app "$APP_NAME" || echo "ボリュームは既に存在します"
+
+# デプロイ
+echo -e "${BLUE}Fly.ioにデプロイしています...${NC}"
+flyctl deploy --app "$APP_NAME" --remote-only
+
+# 完了
+echo -e "${GREEN}デプロイが完了しました！${NC}"
+echo -e "アプリURL: ${BLUE}https://$APP_NAME.fly.dev${NC}"
+echo
+echo -e "${BLUE}ログを確認するには:${NC} flyctl logs --app $APP_NAME"

--- a/scripts/deploy-fly-web.sh
+++ b/scripts/deploy-fly-web.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+set -e
+
+# ShardXをFly.ioにデプロイするスクリプト（Webインターフェース用）
+
+# 色の定義
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+echo -e "${BLUE}=== ShardX Fly.io Webデプロイスクリプト ===${NC}"
+echo
+
+# Fly CLIがインストールされているか確認
+if ! command -v flyctl &> /dev/null; then
+    echo -e "${RED}Fly CLIがインストールされていません。${NC}"
+    echo "インストール方法: curl -L https://fly.io/install.sh | sh"
+    
+    # インストールを試みる
+    read -p "Fly CLIをインストールしますか？ (y/n): " INSTALL_CLI
+    if [[ "$INSTALL_CLI" == "y" || "$INSTALL_CLI" == "Y" ]]; then
+        echo -e "${BLUE}Fly CLIをインストールしています...${NC}"
+        curl -L https://fly.io/install.sh | sh
+        
+        # PATHを更新
+        export PATH=$HOME/.fly/bin:$PATH
+    else
+        echo -e "${RED}Fly CLIが必要です。インストール後に再実行してください。${NC}"
+        exit 1
+    fi
+fi
+
+# ログイン状態を確認
+if ! flyctl auth whoami &> /dev/null; then
+    echo -e "${BLUE}Fly.ioにログインしてください...${NC}"
+    flyctl auth login
+fi
+
+# アプリ名を取得
+read -p "Fly.ioアプリ名を入力してください (例: shardx-web): " APP_NAME
+
+# リージョンを選択
+echo -e "${BLUE}デプロイするリージョンを選択してください:${NC}"
+echo "1) Tokyo (nrt)"
+echo "2) Singapore (sin)"
+echo "3) Los Angeles (lax)"
+echo "4) New York (ewr)"
+echo "5) London (lhr)"
+read -p "リージョン番号を選択してください (1-5): " REGION_NUM
+
+case $REGION_NUM in
+    1) REGION="nrt" ;;
+    2) REGION="sin" ;;
+    3) REGION="lax" ;;
+    4) REGION="ewr" ;;
+    5) REGION="lhr" ;;
+    *) REGION="nrt" ;;
+esac
+
+# 一時ディレクトリを作成
+TEMP_DIR=$(mktemp -d)
+echo -e "${BLUE}一時ディレクトリを作成しました: ${TEMP_DIR}${NC}"
+
+# Webディレクトリをコピー
+cp -r web/* $TEMP_DIR/
+cd $TEMP_DIR
+
+# Dockerfileを作成
+cat > Dockerfile << EOL
+FROM node:18-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm install
+
+COPY . .
+
+EXPOSE 52153
+
+ENV PORT=52153
+ENV NODE_ENV=production
+
+CMD ["npm", "start"]
+EOL
+
+# fly.tomlを作成
+cat > fly.toml << EOL
+# fly.toml - Web Interface
+app = "${APP_NAME}"
+primary_region = "${REGION}"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[env]
+  PORT = "52153"
+  NODE_ENV = "production"
+  API_URL = "https://shardx.fly.dev"
+
+[http]
+  internal_port = 52153
+  force_https = true
+
+[[services]]
+  protocol = "tcp"
+  internal_port = 52153
+  processes = ["app"]
+
+  [[services.ports]]
+    port = 80
+    handlers = ["http"]
+    force_https = true
+
+  [[services.ports]]
+    port = 443
+    handlers = ["tls", "http"]
+
+  [services.concurrency]
+    type = "connections"
+    hard_limit = 1000
+    soft_limit = 500
+
+[[vm]]
+  memory = "512mb"
+  cpu_kind = "shared"
+  cpus = 1
+EOL
+
+# アプリを作成
+echo -e "${BLUE}Fly.ioアプリを作成しています...${NC}"
+flyctl apps create "$APP_NAME" --json || echo "アプリは既に存在します"
+
+# デプロイ
+echo -e "${BLUE}Fly.ioにデプロイしています...${NC}"
+flyctl deploy
+
+# 完了
+echo -e "${GREEN}デプロイが完了しました！${NC}"
+echo -e "アプリURL: ${BLUE}https://$APP_NAME.fly.dev${NC}"
+echo
+echo -e "${BLUE}ログを確認するには:${NC} flyctl logs --app $APP_NAME"
+
+# 一時ディレクトリを削除
+cd -
+rm -rf $TEMP_DIR

--- a/scripts/deploy-render-fix.sh
+++ b/scripts/deploy-render-fix.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+set -e
+
+# ShardXをRenderにデプロイするスクリプト（修正版）
+
+# 色の定義
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+echo -e "${BLUE}=== ShardX Renderデプロイスクリプト（修正版） ===${NC}"
+echo
+
+# 必要なツールの確認
+if ! command -v curl &> /dev/null; then
+    echo -e "${RED}curlがインストールされていません。${NC}"
+    exit 1
+fi
+
+# Renderのデプロイボタンを使用するためのURL
+REPO_URL="https://github.com/enablerdao/ShardX"
+RENDER_DEPLOY_URL="https://render.com/deploy?repo=$REPO_URL"
+
+echo -e "${BLUE}Renderへのデプロイを開始します...${NC}"
+echo -e "以下のURLをブラウザで開いてください:"
+echo -e "${GREEN}$RENDER_DEPLOY_URL${NC}"
+echo
+echo -e "${BLUE}ブラウザでRenderにログインし、デプロイボタンをクリックしてください。${NC}"
+echo -e "デプロイが完了すると、以下のサービスが自動的に作成されます:"
+echo "- shardx-node: ShardXのメインノード"
+echo "- shardx-web: Webインターフェース"
+echo "- redis: キャッシュとメッセージングに使用"
+echo "- shardx-worker: バックグラウンド処理用ワーカー"
+echo
+echo -e "${BLUE}注意: もしheadersエラーが発生した場合は、以下の手順で手動デプロイしてください:${NC}"
+echo "1. Renderダッシュボード(https://dashboard.render.com)にログイン"
+echo "2. 「New +」→「Web Service」をクリック"
+echo "3. GitHubリポジトリ「enablerdao/ShardX」を選択"
+echo "4. 以下の設定を行います:"
+echo "   - Name: shardx-node"
+echo "   - Environment: Docker"
+echo "   - Branch: main"
+echo "   - Dockerfile Path: Dockerfile.simple"
+echo "   - Region: お好みのリージョン"
+echo "   - Plan: Free"
+echo "5. 「Advanced」をクリックして環境変数を設定:"
+echo "   - PORT: 54868"
+echo "   - NODE_ID: render_node"
+echo "   - RUST_LOG: info"
+echo "   - INITIAL_SHARDS: 10"
+echo "   - DATA_DIR: /tmp/shardx-data"
+echo "6. 「Create Web Service」をクリック"
+echo
+echo -e "${BLUE}ブラウザでURLを開きますか？ (y/n):${NC}"
+read -r OPEN_BROWSER
+
+if [[ "$OPEN_BROWSER" == "y" || "$OPEN_BROWSER" == "Y" ]]; then
+    if command -v xdg-open &> /dev/null; then
+        xdg-open "$RENDER_DEPLOY_URL"
+    elif command -v open &> /dev/null; then
+        open "$RENDER_DEPLOY_URL"
+    elif command -v start &> /dev/null; then
+        start "$RENDER_DEPLOY_URL"
+    else
+        echo -e "${RED}ブラウザを自動で開けませんでした。上記のURLを手動でブラウザにコピーしてください。${NC}"
+    fi
+fi
+
+echo
+echo -e "${BLUE}デプロイが完了したら、Renderダッシュボードでサービスの状態を確認してください。${NC}"
+echo -e "Renderダッシュボード: ${GREEN}https://dashboard.render.com/${NC}"


### PR DESCRIPTION
このPRでは、Renderへのデプロイ時に発生する問題を修正しています：

- render.yamlファイルから`headers`セクションを削除（静的Webサービス以外ではサポートされていない）
- 代わりに環境変数`CORS_ENABLED`を追加してCORS設定を有効化
- 改良されたデプロイスクリプト（deploy-render-fix.sh）を追加

この修正により、「headers only supported for static web services」というエラーが解決され、Renderへのデプロイが正常に行えるようになります。