### PR TITLE
Fix Docker build issues for Render deployment

### DIFF
--- a/Dockerfile.render
+++ b/Dockerfile.render
@@ -1,0 +1,73 @@
+FROM rust:1.76-slim-bookworm as builder
+
+WORKDIR /app
+
+# 必要なパッケージをインストール
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    build-essential \
+    pkg-config \
+    libssl-dev \
+    git \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# ソースコードをコピー
+COPY . .
+
+# Rustプロジェクトをビルド
+RUN cargo build --release
+
+# Node.jsをインストールしてWebインターフェースをビルド
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    nodejs \
+    npm \
+    && rm -rf /var/lib/apt/lists/*
+
+# Webインターフェースをビルド
+WORKDIR /app/web
+RUN npm install && npm run build
+
+# 実行用のイメージを作成
+FROM debian:bookworm-slim
+
+WORKDIR /app
+
+# 必要なパッケージをインストール
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    ca-certificates \
+    nginx \
+    && rm -rf /var/lib/apt/lists/*
+
+# バイナリをコピー
+COPY --from=builder /app/target/release/shardx /app/bin/shardx
+RUN chmod +x /app/bin/shardx
+
+# Webインターフェースをコピー
+COPY --from=builder /app/web/dist /app/web
+
+# Nginx設定
+COPY web/nginx.conf /etc/nginx/conf.d/default.conf
+
+# データディレクトリを作成
+RUN mkdir -p /app/data /tmp/shardx-data && chmod 777 /app/data /tmp/shardx-data
+
+# APIポートを公開
+EXPOSE 54867 54868
+
+# 環境変数の設定
+ENV RUST_LOG=info
+ENV DATA_DIR=/app/data
+ENV PORT=54868
+ENV NODE_ID=render_node
+ENV INITIAL_SHARDS=10
+ENV CORS_ENABLED=true
+
+# 起動スクリプト
+COPY scripts/docker-entrypoint.sh /app/
+RUN chmod +x /app/docker-entrypoint.sh
+
+# アプリケーションを実行
+ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/Dockerfile.simple
+++ b/Dockerfile.simple
@@ -12,19 +12,15 @@ RUN apt-get update && \
     lsb-release \
     && rm -rf /var/lib/apt/lists/*
 
-# ShardXのバイナリをダウンロード
-RUN mkdir -p /app/bin && \
-    curl -L -o /app/bin/shardx https://github.com/enablerdao/ShardX/releases/download/v0.1.0/shardx-linux-amd64 && \
-    chmod +x /app/bin/shardx
+# ShardXのバイナリをコピー
+COPY target/release/shardx /app/bin/shardx
+RUN chmod +x /app/bin/shardx
 
 # データディレクトリを作成（一時ディレクトリも使用可能）
 RUN mkdir -p /app/data /tmp/shardx-data && chmod 777 /app/data /tmp/shardx-data
 
-# Webインターフェースをダウンロード
-RUN mkdir -p /app/web && \
-    curl -L -o /tmp/web.tar.gz https://github.com/enablerdao/ShardX/releases/download/v0.1.0/web-dist.tar.gz && \
-    tar -xzf /tmp/web.tar.gz -C /app/web && \
-    rm /tmp/web.tar.gz
+# Webインターフェースをコピー
+COPY web/dist /app/web
 
 # Nginxをインストール
 RUN apt-get update && \

--- a/render.yaml
+++ b/render.yaml
@@ -3,7 +3,7 @@ services:
   - type: web
     name: shardx-node
     env: docker
-    dockerfilePath: ./Dockerfile.simple
+    dockerfilePath: ./Dockerfile.render
     dockerContext: .
     plan: free # 無料プラン
     healthCheckPath: /info
@@ -19,6 +19,8 @@ services:
       - key: DATA_DIR
         value: /tmp/shardx-data # 一時ディレクトリを使用
       - key: REDIS_ENABLED
+        value: "true"
+      - key: CORS_ENABLED
         value: "true"
       - key: REDIS_URL
         fromService:


### PR DESCRIPTION
このPRでは、Renderへのデプロイ時に発生するDockerビルドの問題を修正しています：

- Dockerfile.simpleを修正：リリースファイルのダウンロードではなく、ローカルビルドファイルを使用するように変更
- Dockerfile.renderを新規作成：マルチステージビルドを使用して、ソースからShardXをビルドするDockerfile
- render.yamlを更新：新しいDockerfileを使用するように設定

この修正により、「gzip: stdin: not in gzip format」エラーが解決され、Renderへのデプロイが正常に行えるようになります。