### PR TITLE
インストールスクリプトとドキュメントの追加

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,165 @@
+# ShardX インストールガイド
+
+このドキュメントでは、ShardXをさまざまな方法でインストールする手順を説明します。
+
+## 目次
+
+- [自動インストール](#自動インストール)
+- [手動インストール](#手動インストール)
+- [Dockerを使用したインストール](#dockerを使用したインストール)
+- [ソースからのビルド](#ソースからのビルド)
+- [クラウドへのデプロイ](#クラウドへのデプロイ)
+
+## 自動インストール
+
+ShardXは、ワンライナーのインストールスクリプトを提供しています。これは最も簡単なインストール方法です。
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/enablerdao/ShardX/main/install.sh | bash
+```
+
+特定のバージョンをインストールする場合は、以下のようにバージョンを指定できます：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/enablerdao/ShardX/main/install.sh | bash -s v0.1.0
+```
+
+このスクリプトは以下の処理を行います：
+
+1. OSとアーキテクチャを検出
+2. 必要なディレクトリを作成
+3. バイナリをダウンロード（または必要に応じてソースからビルド）
+4. Webインターフェースをダウンロード
+5. 設定ファイルを作成
+6. PATHにシンボリックリンクを追加
+
+インストール後、以下のコマンドでShardXを起動できます：
+
+```bash
+shardx
+```
+
+## 手動インストール
+
+### 前提条件
+
+- Linux または macOS
+- x86_64 または ARM64 アーキテクチャ
+
+### インストール手順
+
+1. [GitHubリリースページ](https://github.com/enablerdao/ShardX/releases)から、お使いのOSとアーキテクチャに合ったバイナリをダウンロードします。
+
+2. バイナリを実行可能にします：
+
+```bash
+chmod +x shardx-linux-amd64
+```
+
+3. バイナリを適切な場所に移動します：
+
+```bash
+mkdir -p ~/.local/bin
+mv shardx-linux-amd64 ~/.local/bin/shardx
+```
+
+4. PATHが正しく設定されていることを確認します：
+
+```bash
+export PATH="$PATH:$HOME/.local/bin"
+```
+
+5. ShardXを起動します：
+
+```bash
+shardx
+```
+
+## Dockerを使用したインストール
+
+ShardXはDockerイメージも提供しています。
+
+### Dockerイメージを使用する
+
+```bash
+docker pull enablerdao/shardx:latest
+docker run -p 54868:54868 -p 54867:54867 enablerdao/shardx:latest
+```
+
+### Docker Composeを使用する
+
+`docker-compose.yml`ファイルを作成します：
+
+```yaml
+version: '3'
+services:
+  shardx:
+    image: enablerdao/shardx:latest
+    ports:
+      - "54868:54868"
+      - "54867:54867"
+    volumes:
+      - ./data:/app/data
+    environment:
+      - NODE_ID=my_node
+      - INITIAL_SHARDS=32
+      - RUST_LOG=info
+```
+
+そして、以下のコマンドで起動します：
+
+```bash
+docker-compose up -d
+```
+
+## ソースからのビルド
+
+### 前提条件
+
+- Rust 1.70以上
+- Git
+- Node.js 18以上（Webインターフェースをビルドする場合）
+
+### ビルド手順
+
+1. リポジトリをクローンします：
+
+```bash
+git clone https://github.com/enablerdao/ShardX.git
+cd ShardX
+```
+
+2. ShardXをビルドします：
+
+```bash
+cargo build --release
+```
+
+3. Webインターフェースをビルドします（オプション）：
+
+```bash
+cd web
+npm install
+npm run build
+```
+
+4. ShardXを起動します：
+
+```bash
+./target/release/shardx
+```
+
+## クラウドへのデプロイ
+
+ShardXは、さまざまなクラウドプラットフォームにデプロイできます。詳細な手順については、[デプロイガイド](deployment/multi-platform-deployment.md)を参照してください。
+
+### サポートされているプラットフォーム
+
+- [Render](deployment/multi-platform-deployment.md#render)
+- [Railway](deployment/multi-platform-deployment.md#railway)
+- [Heroku](deployment/multi-platform-deployment.md#heroku)
+- [Fly.io](deployment/multi-platform-deployment.md#flyio)
+
+## トラブルシューティング
+
+インストールに問題がある場合は、[トラブルシューティングガイド](deployment/troubleshooting.md)を参照するか、[GitHubのIssue](https://github.com/enablerdao/ShardX/issues)を作成してください。

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,197 @@
+#!/bin/bash
+set -e
+
+# ShardXインストールスクリプト
+# このスクリプトは、ShardXをダウンロードしてインストールします
+
+# 色の定義
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+RED='\033[0;31m'
+YELLOW='\033[0;33m'
+NC='\033[0m' # No Color
+
+echo -e "${BLUE}=== ShardX インストールスクリプト ===${NC}"
+echo
+
+# OSを検出
+OS="$(uname)"
+case $OS in
+  'Linux')
+    OS='linux'
+    ;;
+  'Darwin')
+    OS='macos'
+    ;;
+  *)
+    echo -e "${RED}サポートされていないOS: $OS${NC}"
+    echo "現在、LinuxとmacOSのみサポートしています。"
+    exit 1
+    ;;
+esac
+
+# アーキテクチャを検出
+ARCH="$(uname -m)"
+case $ARCH in
+  'x86_64')
+    ARCH='amd64'
+    ;;
+  'arm64' | 'aarch64')
+    ARCH='arm64'
+    ;;
+  *)
+    echo -e "${RED}サポートされていないアーキテクチャ: $ARCH${NC}"
+    echo "現在、x86_64とarm64のみサポートしています。"
+    exit 1
+    ;;
+esac
+
+echo -e "${BLUE}OS: $OS, アーキテクチャ: $ARCH を検出しました${NC}"
+
+# インストールディレクトリを設定
+INSTALL_DIR="$HOME/.shardx"
+BIN_DIR="$INSTALL_DIR/bin"
+DATA_DIR="$INSTALL_DIR/data"
+CONFIG_DIR="$INSTALL_DIR/config"
+WEB_DIR="$INSTALL_DIR/web"
+
+# 必要なツールの確認
+command -v curl >/dev/null 2>&1 || { echo -e "${RED}curlが必要です${NC}"; exit 1; }
+command -v tar >/dev/null 2>&1 || { echo -e "${RED}tarが必要です${NC}"; exit 1; }
+
+# バージョンを設定
+VERSION="v0.1.0"
+if [ -n "$1" ]; then
+  VERSION="$1"
+fi
+
+echo -e "${BLUE}ShardX $VERSION をインストールします...${NC}"
+
+# インストールディレクトリを作成
+mkdir -p "$BIN_DIR" "$DATA_DIR" "$CONFIG_DIR" "$WEB_DIR"
+
+# GitHubリリースからバイナリをダウンロード
+BINARY_URL="https://github.com/enablerdao/ShardX/releases/download/$VERSION/shardx-$OS-$ARCH"
+echo -e "${BLUE}バイナリをダウンロード中: $BINARY_URL${NC}"
+
+if ! curl -L -o "$BIN_DIR/shardx" "$BINARY_URL"; then
+  echo -e "${YELLOW}リリースバイナリのダウンロードに失敗しました。ソースからビルドします...${NC}"
+  
+  # 必要なツールの確認
+  command -v git >/dev/null 2>&1 || { echo -e "${RED}gitが必要です${NC}"; exit 1; }
+  command -v cargo >/dev/null 2>&1 || { 
+    echo -e "${YELLOW}Rustがインストールされていません。Rustをインストールします...${NC}"
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+    source "$HOME/.cargo/env"
+  }
+  
+  # 一時ディレクトリを作成
+  TMP_DIR=$(mktemp -d)
+  cd "$TMP_DIR"
+  
+  # リポジトリをクローン
+  git clone https://github.com/enablerdao/ShardX.git
+  cd ShardX
+  
+  # 特定のバージョンをチェックアウト（タグがある場合）
+  if [ "$VERSION" != "latest" ]; then
+    git checkout "$VERSION" || echo -e "${YELLOW}指定されたバージョンが見つかりません。mainブランチを使用します。${NC}"
+  fi
+  
+  # ビルド
+  echo -e "${BLUE}ShardXをビルドしています...${NC}"
+  cargo build --release
+  
+  # バイナリをコピー
+  cp target/release/shardx "$BIN_DIR/shardx"
+  
+  # Webインターフェースをビルド
+  if [ -d "web" ]; then
+    echo -e "${BLUE}Webインターフェースをビルドしています...${NC}"
+    cd web
+    
+    # Node.jsの確認
+    if command -v npm >/dev/null 2>&1; then
+      npm install
+      npm run build
+      cp -r dist/* "$WEB_DIR/"
+    else
+      echo -e "${YELLOW}Node.jsがインストールされていないため、Webインターフェースはビルドされません${NC}"
+    fi
+  fi
+  
+  # 一時ディレクトリを削除
+  cd
+  rm -rf "$TMP_DIR"
+else
+  chmod +x "$BIN_DIR/shardx"
+  
+  # Webインターフェースをダウンロード
+  WEB_URL="https://github.com/enablerdao/ShardX/releases/download/$VERSION/web-dist.tar.gz"
+  echo -e "${BLUE}Webインターフェースをダウンロード中: $WEB_URL${NC}"
+  
+  if curl -L -o /tmp/web.tar.gz "$WEB_URL"; then
+    tar -xzf /tmp/web.tar.gz -C "$WEB_DIR"
+    rm /tmp/web.tar.gz
+  else
+    echo -e "${YELLOW}Webインターフェースのダウンロードに失敗しました${NC}"
+  fi
+fi
+
+# 実行ファイルへのシンボリックリンクを作成
+SYMLINK_DIR="$HOME/.local/bin"
+mkdir -p "$SYMLINK_DIR"
+
+if [ -f "$SYMLINK_DIR/shardx" ]; then
+  rm "$SYMLINK_DIR/shardx"
+fi
+
+ln -s "$BIN_DIR/shardx" "$SYMLINK_DIR/shardx"
+
+# PATHを確認
+if [[ ":$PATH:" != *":$SYMLINK_DIR:"* ]]; then
+  echo -e "${YELLOW}$SYMLINK_DIR がPATHに含まれていません。${NC}"
+  echo -e "以下をシェルの設定ファイル（~/.bashrc、~/.zshrc など）に追加してください:"
+  echo -e "${GREEN}export PATH=\"\$PATH:$SYMLINK_DIR\"${NC}"
+fi
+
+# 設定ファイルを作成
+if [ ! -f "$CONFIG_DIR/config.toml" ]; then
+  cat > "$CONFIG_DIR/config.toml" << EOL
+# ShardX設定ファイル
+
+# ノード設定
+[node]
+id = "node1"
+initial_shards = 32
+data_dir = "$DATA_DIR"
+
+# APIサーバー設定
+[api]
+port = 54868
+cors_enabled = true
+
+# Webインターフェース設定
+[web]
+enabled = true
+dir = "$WEB_DIR"
+port = 54867
+
+# ログ設定
+[log]
+level = "info"
+EOL
+fi
+
+# 完了メッセージ
+echo
+echo -e "${GREEN}ShardX $VERSION のインストールが完了しました！${NC}"
+echo
+echo -e "バイナリの場所: ${BLUE}$BIN_DIR/shardx${NC}"
+echo -e "設定ファイル: ${BLUE}$CONFIG_DIR/config.toml${NC}"
+echo -e "データディレクトリ: ${BLUE}$DATA_DIR${NC}"
+echo
+echo -e "ShardXを起動するには: ${GREEN}shardx${NC}"
+echo -e "設定ファイルを指定して起動するには: ${GREEN}shardx --config $CONFIG_DIR/config.toml${NC}"
+echo
+echo -e "詳細なドキュメントは https://github.com/enablerdao/ShardX/docs を参照してください"


### PR DESCRIPTION
このPRでは、ShardXのインストールを簡単にするための機能を追加しています：

- `install.sh`：ワンライナーでShardXをインストールできる自動インストールスクリプト
- `docs/installation.md`：詳細なインストールガイド

### インストールスクリプトの機能

- OSとアーキテクチャの自動検出
- GitHubリリースからのバイナリダウンロード
- リリースが見つからない場合はソースからのビルド
- 設定ファイルの自動生成
- シンボリックリンクの作成

### インストール方法

```bash
curl -fsSL https://raw.githubusercontent.com/enablerdao/ShardX/main/install.sh | bash
```

この変更により、ユーザーはより簡単にShardXをインストールできるようになります。