### PR TITLE
デプロイオプションを追加（Google Cloud Run、Vercel、Netlify）

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,15 @@ shardx
   <a href="https://fly.io/launch/github/enablerdao/ShardX">
     <img src="https://fly.io/static/images/brand/logo-mark-dark.svg" alt="Deploy to Fly.io" height="44px" />
   </a>
+  <a href="https://vercel.com/new/clone?repository-url=https://github.com/enablerdao/ShardX">
+    <img src="https://vercel.com/button" alt="Deploy with Vercel" height="44px" />
+  </a>
+  <a href="https://app.netlify.com/start/deploy?repository=https://github.com/enablerdao/ShardX">
+    <img src="https://www.netlify.com/img/deploy/button.svg" alt="Deploy to Netlify" height="44px" />
+  </a>
+  <a href="https://console.cloud.google.com/cloudshell/editor?shellonly=true&cloudshell_image=gcr.io/cloudrun/button&cloudshell_git_repo=https://github.com/enablerdao/ShardX">
+    <img src="https://storage.googleapis.com/gweb-cloudblog-publish/images/run_on_google_cloud.max-300x300.png" alt="Run on Google Cloud" height="44px" />
+  </a>
 </div>
 
 各プラットフォームの特徴:
@@ -61,6 +70,9 @@ shardx
 - **Railway**: 高速デプロイ、直感的なUI、開発・テスト向け
 - **Heroku**: 安定性と拡張性、PostgreSQL・Redis連携、本番環境向け
 - **Fly.io**: グローバル分散デプロイ、低レイテンシー、本番環境向け
+- **Vercel**: 高速CDN、自動HTTPS、フロントエンド特化（Webインターフェースのみ）
+- **Netlify**: 継続的デプロイ、エッジネットワーク、フロントエンド特化（Webインターフェースのみ）
+- **Google Cloud Run**: サーバーレス、自動スケーリング、本番環境向け
 
 詳細は[デプロイガイド](docs/deployment/multi-platform-deployment.md)を参照してください。
 
@@ -270,7 +282,9 @@ curl https://your-app-url.onrender.com/api/v1/predictions/transaction-count?hori
 - [API リファレンス](docs/api/README.md) - すべてのエンドポイントの説明
 - [デプロイガイド](docs/deployment/multi-platform-deployment.md) - 各クラウドプラットフォームへのデプロイ方法
 - [クロスチェーン機能](docs/cross_chain/README.md) - 異なるブロックチェーンとの連携方法
-- [パフォーマンステスト結果](docs/benchmarks/performance_results.md) - 100,000 TPS達成の詳細
+- [パフォーマンステスト結果](docs/test_results/index.md) - 100,000 TPS達成の詳細
+- [コントリビューションガイド](docs/contributing/index.md) - 開発に参加する方法
+- [ロードマップ](docs/roadmap/index.md) - 今後の開発計画
 
 ## 🤝 コントリビューション
 
@@ -281,7 +295,7 @@ curl https://your-app-url.onrender.com/api/v1/predictions/transaction-count?hori
 3. プルリクエストを送信
 4. フィードバックを受けて改善
 
-詳細は[コントリビューションガイド](CONTRIBUTING.md)を参照してください。
+詳細は[コントリビューションガイド](docs/contributing/index.md)を参照してください。
 
 ## 📄 ライセンス
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -26,7 +26,11 @@ docker run -d -p 54867:54867 -p 54868:54868 --name shardx enablerdao/shardx:late
 
 - [Renderにデプロイ](https://render.com/deploy?repo=https://github.com/enablerdao/ShardX)
 - [Railwayにデプロイ](https://railway.app/template/ShardX)
-- [Vercelにデプロイ](https://vercel.com/new/clone?repository-url=https://github.com/enablerdao/ShardX)
+- [Herokuにデプロイ](https://heroku.com/deploy?template=https://github.com/enablerdao/ShardX)
+- [Fly.ioにデプロイ](https://fly.io/launch/github/enablerdao/ShardX)
+- [Vercelにデプロイ](https://vercel.com/new/clone?repository-url=https://github.com/enablerdao/ShardX)（Webインターフェースのみ）
+- [Netlifyにデプロイ](https://app.netlify.com/start/deploy?repository=https://github.com/enablerdao/ShardX)（Webインターフェースのみ）
+- [Google Cloud Runにデプロイ](https://console.cloud.google.com/cloudshell/editor?shellonly=true&cloudshell_image=gcr.io/cloudrun/button&cloudshell_git_repo=https://github.com/enablerdao/ShardX)
 
 詳細な手順は[デプロイガイド](deployment/multi-platform-deployment.md)を参照してください。
 


### PR DESCRIPTION
このPRでは、ShardXのデプロイオプションを拡充しています：

### 追加したデプロイオプション

1. **Google Cloud Run**
   - サーバーレスコンテナプラットフォーム
   - 自動スケーリング機能
   - デプロイ手順とトラブルシューティング情報を追加

2. **Vercel**（Webインターフェースのみ）
   - 高速CDN、自動HTTPS
   - フロントエンド特化のプラットフォーム

3. **Netlify**（Webインターフェースのみ）
   - 継続的デプロイ、エッジネットワーク
   - フロントエンド特化のプラットフォーム

### 変更内容

- READMEにデプロイボタンとプラットフォーム説明を追加
- クイックスタートガイドのデプロイオプションを更新
- マルチプラットフォームデプロイガイドにGoogle Cloud Runのセクションを追加
- トラブルシューティング情報を更新

この変更により、ユーザーはより多くのクラウドプラットフォームからShardXをデプロイする選択肢を得られます。