### PR TITLE
Google Cloud Shellでのデプロイエラーを修正

### DIFF
--- a/app.json
+++ b/app.json
@@ -5,7 +5,6 @@
   "logo": "https://raw.githubusercontent.com/enablerdao/ShardX/main/web/assets/logo.svg",
   "keywords": ["blockchain", "rust", "shardx", "dag", "proof-of-flow"],
   "website": "https://shardx.org",
-  "success_url": "/",
   "env": {
     "NODE_ID": {
       "description": "ノードの一意の識別子",


### PR DESCRIPTION
このPRでは、Google Cloud Shellでのデプロイエラーを修正しています：

### 修正内容

- `app.json`ファイルから`success_url`フィールドを削除

### エラー内容

Google Cloud Shellでデプロイしようとすると、以下のエラーが発生していました：
```
Error: error attempting to read the app.json from the cloned repository: failed to parse app.json file: failed to parse app.json: json: unknown field "success_url"
```

### 解決策

Google Cloud Shellの`app.json`パーサーは`success_url`フィールドをサポートしていないため、このフィールドを削除しました。これにより、Google Cloud Shellでのデプロイが正常に行えるようになります。

この変更はHerokuなど他のプラットフォームでのデプロイには影響しません。