### PR TITLE
Replitでのバイナリ選択エラーを修正

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,4 +1,4 @@
-run = "cargo run --release"
+run = "cargo run --release --bin shardx"
 hidden = [".git", "target"]
 entrypoint = "src/main.rs"
 
@@ -25,5 +25,5 @@ pattern = "**/*.rs"
 start = ["rust-analyzer"]
 
 [deployment]
-run = ["sh", "-c", "cargo run --release"]
+run = ["sh", "-c", "cargo run --release --bin shardx"]
 deploymentTarget = "cloudrun"


### PR DESCRIPTION
このPRでは、Replitでのバイナリ選択エラーを修正しています：

### エラー内容

Replitで実行すると、以下のエラーが発生していました：
```
error: `cargo run` could not determine which binary to run. Use the `--bin` option to specify a binary, or the `default-run` manifest key.
available binaries: benchmark_100k, cross_chain_bridge_demo, ethereum_bridge_demo, micro_benchmark, pure_benchmark, realistic_benchmark, shardx, simple_benchmark
```

### 修正内容

- `.replit`ファイルの`run`コマンドに`--bin shardx`オプションを追加
- `deployment`セクションの`run`コマンドにも同様に`--bin shardx`オプションを追加

### 解決策

Cargoプロジェクトに複数のバイナリが含まれている場合、どのバイナリを実行するか明示的に指定する必要があります。この修正により、Replitで実行する際に明示的に`shardx`バイナリを指定するようになり、エラーが解消されます。