### PR TITLE
Google Cloud Shellでのデプロイエラーを修正（addons、stack、cronフィールド）

### DIFF
--- a/app.json
+++ b/app.json
@@ -49,16 +49,7 @@
       "size": "basic"
     }
   },
-  "addons": [
-    {
-      "plan": "heroku-postgresql:hobby-dev",
-      "as": "DATABASE"
-    },
-    {
-      "plan": "heroku-redis:hobby-dev",
-      "as": "REDIS"
-    }
-  ],
+
   "buildpacks": [
     {
       "url": "https://github.com/emk/heroku-buildpack-rust"
@@ -69,12 +60,5 @@
   ],
   "scripts": {
     "postdeploy": "cargo run --bin init_db && cd web && npm install && npm run build"
-  },
-  "stack": "heroku-22",
-  "cron": [
-    {
-      "command": "./target/release/shardx --maintenance",
-      "schedule": "0 */6 * * *"
-    }
-  ]
+  }
 }


### PR DESCRIPTION
このPRでは、Google Cloud Shellでのデプロイエラーをさらに修正しています：

### エラー内容

前回の修正後、新たに以下のエラーが発生していました：
```
Error: error attempting to read the app.json from the cloned repository: failed to parse app.json file: failed to parse app.json: json: unknown field "addons"
```

### 修正内容

- `app.json`ファイルから以下のフィールドを削除：
  - `addons`: Heroku固有のアドオン設定
  - `stack`: Heroku固有のスタック設定
  - `cron`: Heroku固有のスケジュール設定

### 解決策

Google Cloud Shellの`app.json`パーサーはHeroku固有のフィールドをサポートしていないため、これらのフィールドを削除しました。これにより、Google Cloud Shellでのデプロイが正常に行えるようになります。

この変更はGoogle Cloud Run向けの修正であり、Herokuでのデプロイには影響する可能性があります。Herokuでデプロイする場合は、これらのフィールドを復元する必要があるかもしれません。