### PR TITLE
Replitでのビルドエラーを修正（libclangとRocksDB）

### DIFF
--- a/replit.nix
+++ b/replit.nix
@@ -10,5 +10,21 @@
     pkgs.libiconv
     pkgs.nodePackages.npm
     pkgs.nodejs
+    pkgs.clang
+    pkgs.llvmPackages.libclang
+    pkgs.rocksdb
+    pkgs.cmake
+    pkgs.gnumake
+    pkgs.gcc
+    pkgs.zlib
+    pkgs.bzip2
+    pkgs.lz4
+    pkgs.snappy
+    pkgs.zstd
   ];
+  env = {
+    LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
+    ROCKSDB_LIB_DIR = "${pkgs.rocksdb}/lib";
+    ROCKSDB_STATIC = "1";
+  };
 }


### PR DESCRIPTION
このPRでは、Replitでのビルドエラーを修正しています。

### エラー内容

Replitでビルドすると、libclangが見つからないエラーが発生していました。

### 修正内容

- `replit.nix`ファイルに必要な依存関係を追加
- 環境変数を設定して正しくビルドできるようにしました