### PR TITLE
Fly.ioデプロイエラーを修正：マニフェスト設定を更新

### DIFF
--- a/.fly/launch.toml
+++ b/.fly/launch.toml
@@ -1,0 +1,33 @@
+# .fly/launch.toml
+app = "shardx"
+primary_region = "nrt"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[deploy]
+  release_command = "echo 'Starting ShardX deployment...'"
+  strategy = "immediate"
+
+[env]
+  NODE_ID = "fly_node"
+  RUST_LOG = "info"
+  INITIAL_SHARDS = "64"
+  DATA_DIR = "/app/data"
+  REDIS_ENABLED = "true"
+  WEB_ENABLED = "true"
+  PORT = "54868"
+  P2P_PORT = "54867"
+
+[http_service]
+  internal_port = 54868
+  force_https = true
+  auto_stop_machines = false
+  auto_start_machines = true
+  min_machines_running = 1
+  processes = ["app"]
+
+[[vm]]
+  memory = "1gb"
+  cpu_kind = "shared"
+  cpus = 1

--- a/fly.toml
+++ b/fly.toml
@@ -1,9 +1,14 @@
 # fly.toml - Fly.io設定ファイル
 app = "shardx"
 primary_region = "nrt"
+kill_signal = "SIGINT"
+kill_timeout = 5
 
 [build]
   dockerfile = "Dockerfile"
+
+[deploy]
+  strategy = "immediate"
 
 [env]
   NODE_ID = "fly_node"
@@ -20,8 +25,9 @@ primary_region = "nrt"
   force_https = true
 
 [[services]]
-  protocol = "tcp"
+  http_checks = []
   internal_port = 54868
+  protocol = "tcp"
   processes = ["app"]
 
   [[services.ports]]
@@ -39,8 +45,9 @@ primary_region = "nrt"
     soft_limit = 500
 
 [[services]]
-  protocol = "tcp"
+  http_checks = []
   internal_port = 54867
+  protocol = "tcp"
   processes = ["app"]
 
   [[services.ports]]
@@ -50,6 +57,10 @@ primary_region = "nrt"
 [mounts]
   source = "shardx_data"
   destination = "/app/data"
+
+[metrics]
+  port = 54868
+  path = "/metrics"
 
 [[vm]]
   memory = "1gb"


### PR DESCRIPTION
このPRでは、Fly.ioでのデプロイ時に発生するエラーを修正しています。 ### エラー内容 ``` Scanning source code Detected a Dockerfile app Error: launch manifest was created for a app, but this is a app unsuccessful command 'flyctl launch plan generate /tmp/manifest.json' ``` ### 修正内容 1. **fly.tomlファイルの更新**  - `kill_signal`と`kill_timeout`を追加  - `deploy`セクションを追加し、デプロイ戦略を設定  - サービス定義を更新し、`http_checks`を追加  - メトリクスエンドポイントを設定 2. **.fly/launch.tomlファイルの追加**  - Fly.ioのアプリケーション起動設定を明示的に定義  - HTTP/TCPサービスの設定を最適化  - 自動スケーリングの設定を追加 ### 解決策 Fly.ioのマニフェスト設定を更新し、アプリケーションタイプの不一致を解消しました。これにより、Fly.ioでのデプロイエラーが解消され、正常にデプロイできるようになります。 