### PR TITLE
Fix snow dependency with conditional compilation

### DIFF
--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -1,5 +1,6 @@
 pub mod anomaly_detector;
 pub mod hash;
+#[cfg(feature = "snow")]
 pub mod secure_channel;
 pub mod signature;
 pub mod threshold_signature;
@@ -8,6 +9,7 @@ pub use anomaly_detector::{
     AnomalyDetector, AnomalyType, DetectedAnomaly, MitigationAction, TransactionMetrics,
 };
 pub use hash::HashManager;
+#[cfg(feature = "snow")]
 pub use secure_channel::{Role, SecureChannel, SecureChannelFactory, SecureStream};
 pub use signature::SignatureManager;
 pub use threshold_signature::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,4 +32,5 @@ mod tests;
 pub use cross_chain::{BridgeConfig, ChainType, CrossChainBridge};
 
 // Re-export external crates for internal use
+#[cfg(feature = "snow")]
 pub(crate) use snow;


### PR DESCRIPTION
## 修正内容

- `snow` クレートの依存関係を条件付きコンパイルで修正
- `src/crypto/mod.rs` で `secure_channel` モジュールを `#[cfg(feature = "snow")]` で囲む
- `src/lib.rs` で `snow` クレートの再エクスポートを `#[cfg(feature = "snow")]` で囲む

## 期待される効果

- `snow` 機能が無効な場合でもコンパイルが成功するようになる
- 依存関係の問題が解消される
- CI/CDパイプラインが正常に動作するようになる